### PR TITLE
Stream DB query rows with a Go iterator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,8 +50,8 @@
   - Parse().Tree.Root.(*ListNode).[].(recurse) where NodeType()==NodeIdentifier replace with StringNode
 - [ ] Modify relative path invocations to point to the local path. https://pkg.go.dev/text/template/parse@go1.22.1#TemplateNode
   - Should be fine?
-- [ ] See if its possible to implement sql queryrows with https://go.dev/wiki/RangefuncExperiment
-  - Not until caddy releases 2.8.0 and upgrades to 1.22.
+- [x] See if its possible to implement sql queryrows with https://go.dev/wiki/RangefuncExperiment
+  - Done: QueryRows returns an iter.Seq[map[string]any] and scans rows lazily.
 - [ ] Add a way to register additional routes dynamically during init
 - [ ] Organize docs according to https://diataxis.fr/
 - [ ] Research alternative template loading strategies:

--- a/dot_db.go
+++ b/dot_db.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"iter"
 	"log/slog"
+	"text/template"
 	"time"
 )
 
@@ -44,47 +46,69 @@ func (c *DotDB) Exec(query string, params ...any) (result sql.Result, err error)
 	return c.tx.Exec(query, params...)
 }
 
-// QueryRows executes a query and buffers all rows into a []map[string]any object.
-func (c *DotDB) QueryRows(query string, params ...any) (rows []map[string]any, err error) {
-	if err = c.makeTx(); err != nil {
-		return
+// QueryRows executes a query and returns an iterator that yields one
+// map[string]any per result row. Rows are scanned lazily as the sequence is
+// consumed instead of being buffered up front, so a `{{range}}` over the result
+// only holds a single row in memory at a time.
+//
+// Errors that occur before iteration starts (opening the transaction, executing
+// the query, reading column metadata) are returned directly. Errors that occur
+// while scanning rows can't be returned from the iterator, so they are raised
+// via panic(template.ExecError{...}); the template engine recovers these and
+// returns them from template execution, aborting it just like a normal error
+// return would.
+func (c *DotDB) QueryRows(query string, params ...any) (iter.Seq[map[string]any], error) {
+	if err := c.makeTx(); err != nil {
+		return nil, err
 	}
 
-	defer func(start time.Time) {
+	start := time.Now()
+	log := func(err error) {
 		c.log.Debug("QueryRows", slog.String("query", query), slog.Any("params", params), slog.Any("error", err), slog.Duration("queryduration", time.Since(start)))
-	}(time.Now())
+	}
 
 	result, err := c.tx.Query(query, params...)
 	if err != nil {
+		log(err)
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
-	defer func() { _ = result.Close() }()
 
-	var columns []string
-
-	// prepare scan output array
-	columns, err = result.Columns()
+	columns, err := result.Columns()
 	if err != nil {
+		_ = result.Close()
+		log(err)
 		return nil, err
 	}
-	n := len(columns)
-	out := make([]any, n)
-	for i := range columns {
-		out[i] = new(any)
-	}
 
-	for result.Next() {
-		err = result.Scan(out...)
-		if err != nil {
-			return nil, err
+	return func(yield func(map[string]any) bool) {
+		var err error
+		defer func() {
+			_ = result.Close()
+			log(err)
+		}()
+
+		n := len(columns)
+		out := make([]any, n)
+		for i := range out {
+			out[i] = new(any)
 		}
-		row := make(map[string]any, n)
-		for i, c := range columns {
-			row[c] = *out[i].(*any)
+
+		for result.Next() {
+			if err = result.Scan(out...); err != nil {
+				panic(template.ExecError{Name: "QueryRows", Err: err})
+			}
+			row := make(map[string]any, n)
+			for i, col := range columns {
+				row[col] = *out[i].(*any)
+			}
+			if !yield(row) {
+				return
+			}
 		}
-		rows = append(rows, row)
-	}
-	return rows, result.Err()
+		if err = result.Err(); err != nil {
+			panic(template.ExecError{Name: "QueryRows", Err: err})
+		}
+	}, nil
 }
 
 // QueryRow executes a query, which must return one row, and returns it as a
@@ -94,10 +118,19 @@ func (c *DotDB) QueryRow(query string, params ...any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(rows) != 1 {
-		return nil, fmt.Errorf("query returned %d rows, expected exactly 1 row", len(rows))
+	var row map[string]any
+	count := 0
+	for r := range rows {
+		count++
+		if count > 1 {
+			return nil, fmt.Errorf("query returned more than 1 row, expected exactly 1 row")
+		}
+		row = r
 	}
-	return rows[0], nil
+	if count != 1 {
+		return nil, fmt.Errorf("query returned %d rows, expected exactly 1 row", count)
+	}
+	return row, nil
 }
 
 // QueryVal executes a query, which must return one row with one column, and

--- a/dot_db_test.go
+++ b/dot_db_test.go
@@ -59,6 +59,76 @@ func TestDotDB_Query(t *testing.T) {
 	}
 }
 
+// TestDotDB_QueryRowsStream renders every row yielded by the QueryRows iterator.
+func TestDotDB_QueryRowsStream(t *testing.T) {
+	db := newTestDB(t)
+	inst := buildInstance(t,
+		map[string]string{
+			"names.html": `{{range .DB.QueryRows "SELECT name FROM users ORDER BY name"}}{{.name}},{{end}}`,
+		},
+		WithDB("DB", db, nil),
+	)
+
+	w := doRequest(inst, http.MethodGet, "/names")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Body.String(); got != "alice,bob," {
+		t.Errorf("body = %q, want %q", got, "alice,bob,")
+	}
+}
+
+// TestDotDB_QueryRowsIterationError verifies that an error encountered partway
+// through iterating the QueryRows result (here a SQLite integer-overflow raised
+// while stepping the second row) aborts template execution cleanly. The
+// iterator can't return the error, so it panics with template.ExecError, which
+// the template engine must recover and turn into a normal execution error
+// rather than letting the panic escape ServeHTTP.
+func TestDotDB_QueryRowsIterationError(t *testing.T) {
+	db := newTestDB(t)
+	inst := buildInstance(t,
+		map[string]string{
+			// The first row (n=1) is yielded successfully; stepping to the
+			// second row triggers a runtime error in SQLite.
+			"boom.html": `{{range .DB.QueryRows "SELECT 1 AS n UNION ALL SELECT abs(-9223372036854775808)"}}{{.n}}{{end}}`,
+		},
+		WithDB("DB", db, nil),
+	)
+
+	w := doRequest(inst, http.MethodGet, "/boom")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestDotDB_QueryRowWrongCount verifies QueryRow rejects results that don't
+// contain exactly one row, aborting template execution in both the zero-row and
+// multiple-row cases.
+func TestDotDB_QueryRowWrongCount(t *testing.T) {
+	db := newTestDB(t)
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"zero rows", "SELECT name FROM users WHERE name='nobody'"},
+		{"multiple rows", "SELECT name FROM users"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := buildInstance(t,
+				map[string]string{
+					"row.html": `{{$r := .DB.QueryRow "` + tc.query + `"}}{{$r.name}}`,
+				},
+				WithDB("DB", db, nil),
+			)
+
+			w := doRequest(inst, http.MethodGet, "/row")
+			if w.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+			}
+		})
+	}
+}
+
 // TestDotDB_AutoCommit verifies the implicit transaction is committed when the
 // template completes without error, persisting writes.
 func TestDotDB_AutoCommit(t *testing.T) {


### PR DESCRIPTION
## Summary

`DotDB.QueryRows` previously buffered the entire result set into a `[]map[string]any` before returning. This changes it to return an `iter.Seq[map[string]any]` that scans rows lazily, so a `{{range}}` over the result holds only one row in memory at a time.

## Details

- **Lazy iteration:** Transaction setup, query execution, and column metadata are read up front (errors returned normally). The returned iterator scans one row at a time and closes the `*sql.Rows` when iteration ends (including early `{{break}}`/partial consumption).
- **Mid-iteration errors:** Errors from `Scan`/`rows.Err()` can't be returned from an iterator, so they panic with `text/template.ExecError`. Verified against Go 1.25's `text/template` that `errRecover` keeps `ExecError` and returns it from `Execute`, so this preserves the previous abort-on-error semantics rather than crashing the request.
- **`QueryRow`:** Rewritten to consume the iterator and short-circuit once a second row appears, instead of buffering the whole result just to count it.

The template API is unchanged: `{{range .DB.QueryRows ...}}` still binds each row to `.`.

## Tests

Added coverage in `dot_db_test.go`:
- `TestDotDB_QueryRowsStream` — iterator yields each row via `{{range}}`.
- `TestDotDB_QueryRowsIterationError` — forces a SQLite runtime error after the first row is yielded, proving the `ExecError` panic is recovered into a clean 500 instead of escaping `ServeHTTP`.
- `TestDotDB_QueryRowWrongCount` — zero-row and multiple-row cases for the rewritten `QueryRow`.

Full `mise test` (go test + coverage, hurl integration via caddy/cli/docker, lint-go, lint-shell, builds) passes.
