### PR TITLE
Make config loading reusable and add reload-driven apps `watchfs` & `git`

### DIFF
--- a/.config/mise/tasks/build-cli
+++ b/.config/mise/tasks/build-cli
@@ -5,4 +5,4 @@ cd $env.ROOT
 
 # Use the default buildmode so the build reuses the prebuild cache on every
 # platform (forcing -buildmode=exe defeats it on darwin; see the dist task).
-^go build -ldflags (xt-ldflags) -o ($env.DIST_DIR | path join xtemplate) ./cmd
+^go build -ldflags (xt-ldflags) -o ($env.DIST_DIR | path join xtemplate) ./cmd/watchfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY cmd ./cmd/
 COPY *.go ./
 RUN GOOS=linux \
     GOARCH=amd64 \
-    go build -ldflags="${LDFLAGS} -X 'github.com/infogulch/xtemplate/app.defaultWatchTemplates=false' -X 'github.com/infogulch/xtemplate/app.defaultListenAddress=0.0.0.0:80'" -o /build/xtemplate ./cmd
+    go build -ldflags="${LDFLAGS} -X 'github.com/infogulch/xtemplate/app.defaultListenAddress=0.0.0.0:80'" -o /build/xtemplate ./cmd
 
 ###
 

--- a/app/app.go
+++ b/app/app.go
@@ -14,7 +14,7 @@ import (
 	"github.com/infogulch/watch"
 )
 
-type Args struct {
+type Config struct {
 	xtemplate.Config
 	Watch          []string `json:"watch_dirs" arg:",separate"`
 	WatchTemplates bool     `json:"watch_templates"`
@@ -24,59 +24,40 @@ type Args struct {
 	ConfigFiles    []string `json:"-" arg:"-f,--config-file,separate"`
 }
 
-func (Args) Epilogue() string {
-	return `Examples:
-    Listen on port 80:
-    $ ./xtemplate --listen :80
+var _ Configurable = (*Config)(nil)
 
-    Specify a context directory and reload when it changes:
-    $ ./xtemplate --template-dir public --watch-templates
+func (a *Config) appconfig() *Config { return a }
 
-    Parse template files matching a custom extension and minify them:
-    $ ./xtemplate --template-ext ".go.html" --minify`
+// these allow for build-time overrides with:
+//
+//	-ldflags="-X 'github.com/infogulch/xtemplate/app.defaultWatchTemplates=false'"
+//
+// Used by the default docker build to adjust xtemplate's defaults to better
+// suit to that environment.
+var defaultWatchTemplates = "true"
+var defaultListenAddress = "0.0.0.0:8080"
+
+// SetDefaults sets the default values for this Config.
+func (a *Config) SetDefaults() {
+	a.WatchTemplates = defaultWatchTemplates == "true"
+	a.Listen = defaultListenAddress
+	a.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(a.LogLevel)}))
+	a.Config.SetDefaults()
 }
 
-// mergeConfig resolves the final configuration by applying JSON sources named by
-// the already-parsed CLI flags onto a fresh defaults base, then re-applying the
-// CLI args so flags take precedence over JSON. The resulting precedence is
-// CLI flags > JSON (--config-file files, then --config values) > defaults.
-//
-// readFile loads --config-file contents (injectable for testing); it may be nil
-// when there are no config files to read.
-func mergeConfig(argv []string, cli Args, readFile func(string) ([]byte, error)) (Args, error) {
-	jsonConfig := defaultArgs
-	decoded := false
-	for _, name := range cli.ConfigFiles {
-		data, err := readFile(name)
-		if err != nil {
-			return Args{}, fmt.Errorf("failed to read config file %q: %w", name, err)
-		}
-		if err := json.Unmarshal(data, &jsonConfig); err != nil {
-			return Args{}, fmt.Errorf("failed to decode config file %q: %w", name, err)
-		}
-		decoded = true
-	}
-	for _, conf := range cli.Configs {
-		if err := json.Unmarshal([]byte(conf), &jsonConfig); err != nil {
-			return Args{}, fmt.Errorf("failed to decode --config value: %w", err)
-		}
-		decoded = true
-	}
-	if !decoded {
-		return cli, nil
-	}
+// Epilogue is called by arg when the user requests help via the cli. Can be
+// overridden by a Configurable implementation.
+func (Config) Epilogue() string {
+	arg0 := os.Args[0]
+	return fmt.Sprintf(`Examples:
+    Listen on port 80:
+    ❯ %[1]s --listen :80
 
-	// Re-apply the CLI flags over the JSON-derived config. go-arg treats the
-	// nonzero fields already present in jsonConfig as defaults, so JSON values
-	// survive unless a corresponding flag was passed.
-	p, err := arg.NewParser(arg.Config{}, &jsonConfig)
-	if err != nil {
-		return Args{}, err
-	}
-	if err := p.Parse(argv); err != nil {
-		return Args{}, fmt.Errorf("failed to re-apply cli flags over json config: %w", err)
-	}
-	return jsonConfig, nil
+    Specify a template directory and reload when it changes:
+    ❯ %[1]s --template-dir public --watch-templates
+
+    Parse template files matching a custom extension and minify them:
+    ❯ %[1]s --template-ext ".go.html" --minify`, arg0)
 }
 
 // version is stamped at build time for releases via
@@ -85,7 +66,7 @@ func mergeConfig(argv []string, cli Args, readFile func(string) ([]byte, error))
 // the module/VCS info embedded by the Go toolchain.
 var version = ""
 
-func (Args) Version() string {
+func (Config) Version() string {
 	if version != "" {
 		return version
 	}
@@ -118,71 +99,128 @@ func (Args) Version() string {
 	return "development"
 }
 
-var defaultWatchTemplates = "true"
-var defaultListenAddress = "0.0.0.0:8080"
-var defaultArgs = Args{WatchTemplates: defaultWatchTemplates == "true", Listen: defaultListenAddress}
-
 // Main can be called from your func main() if you want your program to act like
 // the default xtemplate cli, or use it as a reference for making your own.
-// Provide configs to override the defaults like:
+// Provide config options to override the defaults like:
 //
 //	app.Main(xtemplate.WithFooConfig())
 func Main(overrides ...xtemplate.Option) {
-	config := defaultArgs
-	var log *slog.Logger
+	config, err := LoadConfig(&Config{}, nil)
+	if err == arg.ErrHelp || err == arg.ErrVersion {
+		os.Exit(0)
+	}
+	if err != nil {
+		config.appconfig().Logger.Error("failed to load configuration", slog.Any("error", err))
+		os.Exit(1)
+	}
+	Serve(config, overrides...)
+}
 
-	// Configuration precedence, highest priority first:
-	//
-	//  1. CLI flags
-	//  2. JSON from --config values and --config-file files (later sources
-	//     override earlier ones; files are applied before inline values)
-	//  3. built-in defaults (defaultArgs + struct `default` tags)
-	//
-	// This is implemented with a two-pass parse: parse the CLI once to discover
-	// which config files/values to load, decode those onto a fresh defaults base,
-	// then re-parse the CLI over the decoded result so flags win over JSON.
+// Configurable is satisfied by *Config and by a pointer to any struct that embeds
+// Config and implements New. Implementers may implement SetDefaults and Epilogue
+// at their discretion, since the embedded Config implements them natively.
+type Configurable interface {
+	appconfig() *Config
+
+	// SetDefaults can be overridden to provide custom default values
+	// configuration defined by the Configurable
+	SetDefaults()
+
+	// Epilogue can be overridden to provide a custom epilogue message for help
+	// output. Consider combining your custom epilogue with the embedded Config's
+	// Epilogue.
+	Epilogue() string
+}
+
+// LoadConfig loads the app configuration, merging sources in priority order:
+//
+//	CLI flags > JSON cli > JSON file > defaults
+//
+// This function will load configuration into any struct implementing the
+// Configurable interface. To get the merged configuration, call this function
+// with a pointer to the config struct. Pass nil `args` to use the default os.Args.
+//
+// Note: to give CLI args precedence over JSON sources, CLI args are parsed twice:
+// first to discover which config files to load, then again at the end to override any
+// values set by json sources.
+func LoadConfig[T Configurable](config T, args []string) (T, error) {
+	config.appconfig().SetDefaults()
+	config.SetDefaults()
+	if args == nil {
+		args = os.Args[1:]
+	}
+
+	// parse CLI args to discover config files/values to load
 	{
-		arg.MustParse(&config)
-		config.SetDefaults()
-
-		level := config.LogLevel
-		log = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(level)}))
-
-		merged, err := mergeConfig(os.Args[1:], config, os.ReadFile)
+		p, err := arg.NewParser(arg.Config{}, config)
 		if err != nil {
-			log.Error("failed to load configuration", slog.Any("error", err))
-			os.Exit(1)
+			return config, err
 		}
-		config = merged
+		// call MustParse to handle arg parse errors and version/help flags
+		p.MustParse(args)
+	}
 
-		if config.LogLevel != level {
-			log = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(config.LogLevel)}))
+	// parse json file/cli config
+	appconfig := config.appconfig()
+	for _, name := range appconfig.ConfigFiles {
+		data, err := os.ReadFile(name)
+		if err != nil {
+			return config, fmt.Errorf("failed to read config file %q: %w", name, err)
 		}
+		if err := json.Unmarshal(data, config); err != nil {
+			return config, fmt.Errorf("failed to decode config file %q: %w", name, err)
+		}
+	}
+	for _, conf := range appconfig.Configs {
+		if err := json.Unmarshal([]byte(conf), config); err != nil {
+			return config, fmt.Errorf("failed to decode --config value: %w", err)
+		}
+	}
 
-		config.Logger = log
+	// parse CLI args again to preserve the defined config precedence
+	{
+		p, err := arg.NewParser(arg.Config{}, config)
+		if err != nil {
+			return config, err
+		}
+		if err := p.Parse(args); err != nil {
+			return config, fmt.Errorf("failed to parse cli flags: %w", err)
+		}
+	}
 
-		log.Debug("loaded configuration", slog.Any("config", &config))
+	appconfig.Logger.Debug("loaded configuration", slog.Any("config", config))
+	return config, nil
+}
+
+// Serve builds the xtemplate server from config and serves it, owning the
+// reload semantics. If config.Reload is already set it drives reloads (e.g. a
+// remote source set by the caller); otherwise Serve falls back to watching
+// local template directories with fsnotify. This call blocks until the server
+// stops.
+func Serve(configurable Configurable, overrides ...xtemplate.Option) {
+	config := configurable.appconfig()
+
+	if config.Reload == nil && config.WatchTemplates && config.TemplatesFS == nil {
+		config.Watch = append(config.Watch, config.TemplatesDir)
+	}
+
+	if config.Reload == nil && len(config.Watch) != 0 {
+		watchCh := make(chan []xtemplate.Option)
+		_, err := watch.Watch(config.Watch, 200*time.Millisecond, config.Logger.WithGroup("fswatch"), func() bool {
+			watchCh <- nil
+			return true
+		})
+		if err != nil {
+			config.Logger.Info("failed to watch directories", slog.Any("error", err), slog.Any("directories", config.Watch))
+			os.Exit(4)
+		}
+		config.Reload = watchCh
 	}
 
 	server, err := config.Server(overrides...)
 	if err != nil {
-		log.Error("failed to load xtemplate", slog.Any("error", err))
+		config.Logger.Error("failed to start server", slog.Any("error", err))
 		os.Exit(2)
 	}
-
-	if config.WatchTemplates && config.TemplatesFS == nil {
-		config.Watch = append(config.Watch, config.TemplatesDir)
-	}
-	if len(config.Watch) != 0 {
-		_, err := watch.Watch(config.Watch, 200*time.Millisecond, log.WithGroup("fswatch"), func() bool {
-			_ = server.Reload()
-			return true
-		})
-		if err != nil {
-			log.Info("failed to watch directories", slog.Any("error", err), slog.Any("directories", config.Watch))
-			os.Exit(4)
-		}
-	}
-
-	log.Info("server stopped", slog.Any("exit", server.Serve(config.Listen)))
+	config.Logger.Info("server stopped", slog.Any("exit", server.Serve(config.Listen)))
 }

--- a/app/app.go
+++ b/app/app.go
@@ -6,22 +6,18 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
-	"time"
 
 	"github.com/infogulch/xtemplate"
 
 	"github.com/alexflint/go-arg"
-	"github.com/infogulch/watch"
 )
 
 type Config struct {
 	xtemplate.Config
-	Watch          []string `json:"watch_dirs" arg:",separate"`
-	WatchTemplates bool     `json:"watch_templates"`
-	Listen         string   `json:"listen" arg:"-l"`
-	LogLevel       int      `json:"log_level" default:"-2"`
-	Configs        []string `json:"-" arg:"-c,--config,separate"`
-	ConfigFiles    []string `json:"-" arg:"-f,--config-file,separate"`
+	Listen      string   `json:"listen" arg:"-l"`
+	LogLevel    int      `json:"log_level" default:"-2"`
+	Configs     []string `json:"-" arg:"-c,--config,separate"`
+	ConfigFiles []string `json:"-" arg:"-f,--config-file,separate"`
 }
 
 var _ Configurable = (*Config)(nil)
@@ -30,16 +26,14 @@ func (a *Config) appconfig() *Config { return a }
 
 // these allow for build-time overrides with:
 //
-//	-ldflags="-X 'github.com/infogulch/xtemplate/app.defaultWatchTemplates=false'"
+//	-ldflags="-X 'github.com/infogulch/xtemplate/app.defaultListenAddress=false'"
 //
 // Used by the default docker build to adjust xtemplate's defaults to better
 // suit to that environment.
-var defaultWatchTemplates = "true"
 var defaultListenAddress = "0.0.0.0:8080"
 
 // SetDefaults sets the default values for this Config.
 func (a *Config) SetDefaults() {
-	a.WatchTemplates = defaultWatchTemplates == "true"
 	a.Listen = defaultListenAddress
 	a.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(a.LogLevel)}))
 	a.Config.SetDefaults()
@@ -106,9 +100,6 @@ func (Config) Version() string {
 //	app.Main(xtemplate.WithFooConfig())
 func Main(overrides ...xtemplate.Option) {
 	config, err := LoadConfig(&Config{}, nil)
-	if err == arg.ErrHelp || err == arg.ErrVersion {
-		os.Exit(0)
-	}
 	if err != nil {
 		config.appconfig().Logger.Error("failed to load configuration", slog.Any("error", err))
 		os.Exit(1)
@@ -192,31 +183,9 @@ func LoadConfig[T Configurable](config T, args []string) (T, error) {
 	return config, nil
 }
 
-// Serve builds the xtemplate server from config and serves it, owning the
-// reload semantics. If config.Reload is already set it drives reloads (e.g. a
-// remote source set by the caller); otherwise Serve falls back to watching
-// local template directories with fsnotify. This call blocks until the server
-// stops.
-func Serve(configurable Configurable, overrides ...xtemplate.Option) {
-	config := configurable.appconfig()
-
-	if config.Reload == nil && config.WatchTemplates && config.TemplatesFS == nil {
-		config.Watch = append(config.Watch, config.TemplatesDir)
-	}
-
-	if config.Reload == nil && len(config.Watch) != 0 {
-		watchCh := make(chan []xtemplate.Option)
-		_, err := watch.Watch(config.Watch, 200*time.Millisecond, config.Logger.WithGroup("fswatch"), func() bool {
-			watchCh <- nil
-			return true
-		})
-		if err != nil {
-			config.Logger.Info("failed to watch directories", slog.Any("error", err), slog.Any("directories", config.Watch))
-			os.Exit(4)
-		}
-		config.Reload = watchCh
-	}
-
+// Serve sets up the xtemplate server from config and serves it.
+// Serve blocks until the server stops.
+func Serve(config *Config, overrides ...xtemplate.Option) {
 	server, err := config.Server(overrides...)
 	if err != nil {
 		config.Logger.Error("failed to start server", slog.Any("error", err))

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,102 +1,148 @@
 package app
 
 import (
+	"os"
 	"testing"
-
-	"github.com/alexflint/go-arg"
 )
 
-// parseCLI mirrors Main's first pass: parse argv onto a copy of defaultArgs and
-// apply Defaults, returning the resulting Args.
-func parseCLI(t *testing.T, argv []string) Args {
-	t.Helper()
-	cfg := defaultArgs
-	p, err := arg.NewParser(arg.Config{}, &cfg)
+func TestLoadConfig_GetsArgsFromOSArgs(t *testing.T) {
+	savedArgs := os.Args
+	defer func() { os.Args = savedArgs }()
+	os.Args = []string{"xtemplate", "--listen", ":7777"}
+	config, err := LoadConfig(&Config{}, nil)
 	if err != nil {
-		t.Fatalf("failed to construct parser: %v", err)
+		t.Fatalf("LoadConfig error: %v", err)
 	}
-	if err := p.Parse(argv); err != nil {
-		t.Fatalf("failed to parse %v: %v", argv, err)
+	if config.Listen != ":7777" {
+		t.Errorf("Listen = %q, want %q (from OS args)", config.Listen, ":7777")
 	}
-	cfg.SetDefaults()
-	return cfg
 }
 
 func TestArgsMinifyDefault(t *testing.T) {
 	// No --minify flag: the default:"true" tag makes Minify a non-nil true.
-	cfg := parseCLI(t, nil)
-	if cfg.Minify == nil || !*cfg.Minify {
-		t.Errorf("Minify = %v, want non-nil true by default", cfg.Minify)
+	config, err := LoadConfig(&Config{}, []string{})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if config.Minify == nil || !*config.Minify {
+		t.Errorf("Minify = %v, want non-nil true by default", config.Minify)
 	}
 
 	// --minify=false explicitly disables it.
-	cfg = parseCLI(t, []string{"--minify=false"})
-	if cfg.Minify == nil || *cfg.Minify {
-		t.Errorf("Minify = %v, want non-nil false when --minify=false", cfg.Minify)
+	config, err = LoadConfig(&Config{}, []string{"--minify=false"})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if config.Minify == nil || *config.Minify {
+		t.Errorf("Minify = %v, want non-nil false when --minify=false", config.Minify)
 	}
 }
 
-func TestMergeConfig_NoSources(t *testing.T) {
-	argv := []string{"--listen", ":5555"}
-	cli := parseCLI(t, argv)
-	merged, err := mergeConfig(argv, cli, nil)
+func TestLoadConfig_NoSources(t *testing.T) {
+	config, err := LoadConfig(&Config{}, []string{"--listen", ":5555"})
 	if err != nil {
 		t.Fatalf("mergeConfig error: %v", err)
 	}
-	if merged.Listen != ":5555" {
-		t.Errorf("Listen = %q, want %q", merged.Listen, ":5555")
+	if config.Listen != ":5555" {
+		t.Errorf("Listen = %q, want %q", config.Listen, ":5555")
 	}
 }
 
-func TestMergeConfig_JSONApplied(t *testing.T) {
-	argv := []string{"-c", `{"minify":false,"listen":":9999"}`}
-	cli := parseCLI(t, argv)
-	merged, err := mergeConfig(argv, cli, nil)
+func TestLoadConfig_JSONApplied(t *testing.T) {
+	config, err := LoadConfig(&Config{}, []string{"-c", `{"minify":false,"listen":":9999"}`})
 	if err != nil {
 		t.Fatalf("mergeConfig error: %v", err)
 	}
-	if merged.Listen != ":9999" {
-		t.Errorf("Listen = %q, want %q (from JSON)", merged.Listen, ":9999")
+	if config.Listen != ":9999" {
+		t.Errorf("Listen = %q, want %q (from JSON arg)", config.Listen, ":9999")
 	}
-	if merged.Minify == nil || *merged.Minify {
-		t.Errorf("Minify = %v, want non-nil false (from JSON)", merged.Minify)
+	if config.Minify == nil || *config.Minify {
+		t.Errorf("Minify = %v, want non-nil false (from JSON arg)", config.Minify)
 	}
 }
 
-func TestMergeConfig_CLIOverridesJSON(t *testing.T) {
+func TestLoadConfig_CLIOverridesJSON(t *testing.T) {
 	argv := []string{"-c", `{"listen":":9999"}`, "--listen", ":7777"}
-	cli := parseCLI(t, argv)
-	merged, err := mergeConfig(argv, cli, nil)
+	config, err := LoadConfig(&Config{}, argv)
 	if err != nil {
 		t.Fatalf("mergeConfig error: %v", err)
 	}
-	if merged.Listen != ":7777" {
-		t.Errorf("Listen = %q, want %q (CLI must override JSON)", merged.Listen, ":7777")
+	if config.Listen != ":7777" {
+		t.Errorf("Listen = %q, want %q (CLI must override JSON)", config.Listen, ":7777")
 	}
 }
 
-func TestMergeConfig_FileSource(t *testing.T) {
-	argv := []string{"-f", "conf.json"}
-	cli := parseCLI(t, argv)
-	read := func(name string) ([]byte, error) {
-		if name != "conf.json" {
-			t.Errorf("readFile called with %q, want %q", name, "conf.json")
+func TestLoadConfig_FileSource(t *testing.T) {
+	tmpFileName, cleanup := mkTemp(t, "conf-*.json", `{"listen":":1234"}`)
+	defer cleanup()
+	config, err := LoadConfig(&Config{}, []string{"-f", tmpFileName, "--templates-dir", "hello"})
+	if err != nil {
+		t.Fatalf("mergeConfig error: %v", err)
+	}
+	if config.Listen != ":1234" {
+		t.Errorf("Listen = %q, want %q (from config file)", config.Listen, ":1234")
+	}
+	if config.TemplatesDir != "hello" {
+		t.Errorf("TemplatesDir = %q, want %q (json must not clobber unnamed cli arg)", config.TemplatesDir, "hello")
+	}
+}
+
+func mkTemp(t *testing.T, name, content string) (string, func()) {
+	tmpFile, err := os.CreateTemp("", name)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	tmpFileName := tmpFile.Name()
+	n, err := tmpFile.Write([]byte(content))
+	if err != nil || n != len(content) {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return tmpFileName, func() {
+		err := tmpFile.Close()
+		if err != nil {
+			t.Fatalf("failed to close temp file: %v", err)
 		}
-		return []byte(`{"listen":":1234"}`), nil
-	}
-	merged, err := mergeConfig(argv, cli, read)
-	if err != nil {
-		t.Fatalf("mergeConfig error: %v", err)
-	}
-	if merged.Listen != ":1234" {
-		t.Errorf("Listen = %q, want %q (from config file)", merged.Listen, ":1234")
+		err = os.Remove(tmpFileName)
+		if err != nil {
+			t.Errorf("failed to remove temp file: %v", err)
+		}
 	}
 }
 
-func TestMergeConfig_BadJSON(t *testing.T) {
-	argv := []string{"-c", `{not valid json`}
-	cli := parseCLI(t, argv)
-	if _, err := mergeConfig(argv, cli, nil); err == nil {
+func TestLoadConfig_LoggerSetWithConfigSource(t *testing.T) {
+	config, err := LoadConfig(&Config{}, []string{"-c", `{"listen":":9999"}`})
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if config.Logger == nil {
+		t.Fatal("LoadConfig returned config with nil Logger after decoding a config source")
+	}
+}
+
+func TestLoadConfig_BadJSON(t *testing.T) {
+	config, err := LoadConfig(&Config{}, []string{"-c", `{not valid json`})
+	if err == nil {
 		t.Error("expected an error for malformed JSON, got nil")
+	}
+	if config.Logger == nil {
+		t.Error("expected Logger to be set after loading config even with bad JSON, got nil")
+	}
+}
+
+type testConfigDoesNotCallSetDefaults struct {
+	Config
+}
+
+func (c *testConfigDoesNotCallSetDefaults) SetDefaults() {
+	// Test what happens when we don't call the embedded SetDefaults
+}
+
+func TestLoadConfig_SetsLoggerWhenOverriding(t *testing.T) {
+	config, err := LoadConfig(&testConfigDoesNotCallSetDefaults{}, []string{"-c", `{"listen":":9999"}`})
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if config.Logger == nil {
+		t.Errorf("LoadConfig returned config with nil Logger")
 	}
 }

--- a/app/git/gitapp.go
+++ b/app/git/gitapp.go
@@ -1,0 +1,167 @@
+// Package git serves an xtemplate site from a git repository, reusing app's
+// config loading machinery. The server starts immediately with an empty FS and
+// begins serving once the local git repo is cloned and ready.
+//
+// Design note: this implementation shells out to installed `git` binary instead
+// of adding an application dependency, and re-clones on every change instead of
+// managing worktrees. Switch to go-git / worktrees if cold-clone latency or
+// disk churn ever matters.
+package git
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/infogulch/xtemplate"
+	"github.com/infogulch/xtemplate/app"
+	"github.com/spf13/afero"
+)
+
+type gitConfig struct {
+	GitRepo     string        `json:"git_repo" arg:"--git-repo"`
+	GitRef      string        `json:"git_ref" arg:"--git-ref"`
+	GitInterval time.Duration `json:"git_interval" arg:"--git-interval"`
+}
+
+// Config extends the default xtemplate cli with flags to configure the git source.
+type Config struct {
+	app.Config
+	gitConfig
+}
+
+func (a *Config) SetDefaults() {
+	a.Config.SetDefaults()
+	a.GitInterval = 15 * time.Second
+}
+
+var _ app.Configurable = &Config{}
+
+func Main(overrides ...xtemplate.Option) {
+	config, err := app.LoadConfig(&Config{}, nil)
+	if err != nil {
+		config.Logger.Error("failed to load configuration", slog.Any("error", err))
+		os.Exit(1)
+	}
+	if config.GitRepo == "" {
+		config.Logger.Error("missing required --git-repo (or git_repo in config)")
+		os.Exit(1)
+	}
+
+	// Start with an empty FS; the poller swaps in the real templates once the
+	// repo is available.
+	config.TemplatesFS = afero.NewMemMapFs()
+	config.Reload = gitReload(config)
+
+	app.Serve(&config.Config, overrides...)
+}
+
+// gitReload polls url@ref and returns a channel that emits a WithTemplateFS
+// option each time ref's commit changes, suitable for xtemplate.Config.Reload.
+// It checks immediately, then every interval. Failures are logged and retried.
+func gitReload(config *Config) <-chan []xtemplate.Option {
+	ch := make(chan []xtemplate.Option)
+	go func() {
+		var last string
+		var dirs []string // recent clones; kept alive while old instances drain
+		check := func() {
+			sha, err := lsRemote(config.Ctx, config.GitRepo, config.GitRef)
+			if err != nil {
+				config.Logger.Warn("ls-remote failed", slog.Any("error", err))
+				return
+			}
+			if sha == last {
+				return
+			}
+			newdir, err := clone(config.Ctx, config.GitRepo, config.GitRef)
+			if err != nil {
+				config.Logger.Warn("clone failed", slog.Any("error", err))
+				return
+			}
+			config.Logger.Info("reloading from new commit", slog.String("commit", sha), slog.String("dir", newdir))
+			select {
+			case ch <- []xtemplate.Option{xtemplate.WithTemplateFS(subFS(newdir, config.TemplatesDir))}:
+			case <-config.Ctx.Done():
+				_ = os.RemoveAll(newdir)
+				return
+			}
+			last = sha
+			dirs = append(dirs, newdir)
+			for len(dirs) > 2 {
+				_ = os.RemoveAll(dirs[0])
+				dirs = dirs[1:]
+			}
+		}
+
+		check()
+		ticker := time.NewTicker(config.GitInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-config.Ctx.Done():
+				return
+			case <-ticker.C:
+				check()
+			}
+		}
+	}()
+	return ch
+}
+
+func subFS(dir, subdir string) afero.Fs {
+	return afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(dir, subdir))
+}
+
+// clone makes a shallow clone of url@ref into a fresh temp dir and returns its
+// path. An empty ref clones the repository's default branch.
+func clone(ctx context.Context, url, ref string) (string, error) {
+	dir, err := os.MkdirTemp("", "xtemplate-git-")
+	if err != nil {
+		return "", err
+	}
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, dir)
+	if out, err := exec.CommandContext(ctx, "git", args...).CombinedOutput(); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", fmt.Errorf("git clone: %w: %s", err, out)
+	}
+	return dir, nil
+}
+
+// lsRemote returns the commit SHA that ref points to on the remote without
+// cloning. An empty ref resolves the remote's HEAD.
+func lsRemote(ctx context.Context, url, ref string) (string, error) {
+	if ref == "" {
+		ref = "HEAD"
+	}
+	out, err := exec.CommandContext(ctx, "git", "ls-remote", url, ref).Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote: %w", err)
+	}
+	return parseLsRemote(string(out))
+}
+
+// parseLsRemote returns the SHA from the first line of `git ls-remote` output,
+// where each line is "<sha>\t<refname>".
+func parseLsRemote(out string) (string, error) {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", fmt.Errorf("ref not found on remote")
+	}
+	// A single-ref query returns one line with no trailing newline; Cut
+	// reports ok=false and returns the whole string, which is the line we want.
+	line, _, _ := strings.Cut(out, "\n")
+	sha, _, ok := strings.Cut(line, "\t")
+	if !ok || sha == "" {
+		return "", fmt.Errorf("malformed ls-remote line: %q", line)
+	}
+	return sha, nil
+}

--- a/app/git/gitapp_test.go
+++ b/app/git/gitapp_test.go
@@ -1,0 +1,101 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/infogulch/xtemplate"
+	"github.com/infogulch/xtemplate/app"
+	"github.com/spf13/afero"
+)
+
+func TestParseLsRemote(t *testing.T) {
+	sha, err := parseLsRemote("9d291430abc\trefs/heads/main\n0000\trefs/heads/other\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sha != "9d291430abc" {
+		t.Errorf("sha = %q, want %q", sha, "9d291430abc")
+	}
+
+	if _, err := parseLsRemote("   \n"); err == nil {
+		t.Error("expected error for empty output, got nil")
+	}
+	if _, err := parseLsRemote("no-tab-here"); err == nil {
+		t.Error("expected error for malformed line, got nil")
+	}
+}
+
+// TestGitReload_PollsLocalRepo exercises the full poller against a real local
+// git repo. It is a regression test for a nil Config.Ctx: gitReload shells out
+// with exec.CommandContext(config.Ctx, ...), which panics on a nil context, so
+// this would crash on startup if LoadConfig failed to initialize Ctx.
+func TestGitReload_PollsLocalRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git("init", "-q")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "test")
+	if err := os.MkdirAll(filepath.Join(repo, "templates"), 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "templates", "index.html"), []byte("HELLO"), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "initial")
+
+	config, err := app.LoadConfig(&Config{}, []string{"--git-repo", repo})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if config.Ctx == nil {
+		t.Fatal("config.Ctx is nil after LoadConfig; gitReload would panic in exec.CommandContext")
+	}
+
+	// Use a testing context so the poller goroutine stops at test end.
+	config.Ctx = t.Context()
+	config.GitInterval = time.Hour // rely on the immediate first check
+
+	ch := gitReload(config)
+
+	var opts []xtemplate.Option
+	select {
+	case opts = <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for gitReload to emit a reload option")
+	}
+
+	// Apply the emitted options and confirm the templates FS serves the repo
+	// contents from under the templates dir.
+	var c xtemplate.Config
+	for _, o := range opts {
+		if err := o(&c); err != nil {
+			t.Fatalf("applying reload option: %v", err)
+		}
+	}
+	if c.TemplatesFS == nil {
+		t.Fatal("reload option did not set TemplatesFS")
+	}
+	got, err := afero.ReadFile(c.TemplatesFS, "index.html")
+	if err != nil {
+		t.Fatalf("reading index.html from cloned FS: %v", err)
+	}
+	if string(got) != "HELLO" {
+		t.Errorf("index.html = %q, want %q", got, "HELLO")
+	}
+}

--- a/app/watchfs/watchfsapp.go
+++ b/app/watchfs/watchfsapp.go
@@ -1,0 +1,52 @@
+// watchfs reloads the server upon changes to the templates directory or other
+// configured directories. This is xtemplate's default app.
+package watchfs
+
+import (
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/infogulch/watch"
+	"github.com/infogulch/xtemplate"
+	"github.com/infogulch/xtemplate/app"
+)
+
+type Config struct {
+	app.Config
+
+	// Watch lists extra directories to watch for changes, in addition to the
+	// templates directory.
+	Watch []string `json:"watch_dirs" arg:",separate"`
+}
+
+var _ app.Configurable = (*Config)(nil)
+
+func Main(options ...xtemplate.Option) {
+	config, err := app.LoadConfig(&Config{}, nil)
+	if err != nil {
+		config.Logger.Info("failed to load config", slog.Any("error", err))
+		os.Exit(1)
+	}
+	err = setReload(config)
+	if err != nil {
+		config.Logger.Info("failed to watch directories", slog.Any("error", err), slog.Any("directories", config.Watch))
+		os.Exit(4)
+	}
+	app.Serve(&config.Config, options...)
+}
+
+func setReload(config *Config) error {
+	config.Watch = append(config.Watch, config.TemplatesDir)
+
+	watchCh := make(chan []xtemplate.Option)
+	_, err := watch.Watch(config.Watch, 200*time.Millisecond, config.Logger.WithGroup("fswatch"), func() bool {
+		watchCh <- nil
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	config.Reload = watchCh
+	return nil
+}

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -1,0 +1,14 @@
+// Git-backed xtemplate CLI package. Serves templates from a git repository,
+// polling for changes and hot-reloading. To customize, copy this file to a new
+// package and pass config overrides to appgit.Main.
+package main
+
+import (
+	"github.com/infogulch/xtemplate/app/git"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+func main() {
+	git.Main()
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
-// Default CLI package. To customize, copy this file to a new unique package and
-// import dbs and provide config overrides.
+// Basic xtemplate CLI package. To customize, copy this file to a new unique
+// package to configured your db drivers and provide config overrides.
 package main
 
 import (

--- a/cmd/watchfs/main.go
+++ b/cmd/watchfs/main.go
@@ -1,0 +1,14 @@
+// The default xtemplate CLI package. Watches the templates directory and
+// reloads the server when they change. To customize, copy this file to a new
+// package and pass config overrides to watchfs.Main.
+package main
+
+import (
+	"github.com/infogulch/xtemplate/app/watchfs"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+func main() {
+	watchfs.Main()
+}

--- a/config.go
+++ b/config.go
@@ -64,6 +64,16 @@ type Config struct {
 
 	// The default logger. Defaults to `slog.Default()`.
 	Logger *slog.Logger `json:"-" arg:"-"`
+
+	// Reload, when non-nil, triggers server.Reload(opts...) on each receive.
+	// Send options to mutate the config for that reload (e.g. WithTemplateFS to
+	// swap the templates source). Send nil to reload in place. Close the channel
+	// to stop the consumer. The caller owns the source and any debounce.
+	//
+	// Options apply to a copy of the config per reload, so they are not sticky:
+	// the next reload starts from the original config again. Use a single reload
+	// source per server unless you persist options into the base config yourself.
+	Reload <-chan []Option `json:"-" arg:"-"`
 }
 
 // HandlerRoute pairs a ServeMux pattern with an http.Handler.

--- a/instance_test.go
+++ b/instance_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -215,6 +216,42 @@ func TestServer_EmptyFSWithHandler(t *testing.T) {
 	}
 	if w.Code != http.StatusNoContent {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestServer_ReloadChannel(t *testing.T) {
+	fs1 := newMemFS(t, map[string]string{"index.html": "V1"})
+	fs2 := newMemFS(t, map[string]string{"index.html": "V2"})
+
+	reload := make(chan []Option)
+	cfg := New()
+	cfg.Reload = reload
+	server, err := cfg.Server(WithTemplateFS(fs1))
+	if err != nil {
+		t.Fatalf("failed to build server: %v", err)
+	}
+	defer server.Stop()
+
+	get := func() string {
+		w := httptest.NewRecorder()
+		server.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		return w.Body.String()
+	}
+
+	if body := get(); !strings.Contains(body, "V1") {
+		t.Fatalf("before reload body = %q, want it to contain V1", body)
+	}
+
+	// Send options through the channel to swap the templates FS, then wait for
+	// the consumer goroutine to apply the reload by polling for the new content.
+	reload <- []Option{WithTemplateFS(fs2)}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(get(), "V2") {
+		if time.Now().After(deadline) {
+			t.Fatalf("after reload body = %q, want it to contain V2", get())
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -44,6 +44,26 @@ func (config Config) Server(cfgs ...Option) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if config.Reload != nil {
+		go func() {
+			log := config.Logger.WithGroup("reload")
+			for {
+				select {
+				case <-config.Ctx.Done():
+					return
+				case opts, ok := <-config.Reload:
+					if !ok {
+						return
+					}
+					if err := server.Reload(opts...); err != nil {
+						log.Error("reload failed", slog.Any("error", err))
+					}
+				}
+			}
+		}()
+	}
+
 	return server, nil
 }
 


### PR DESCRIPTION
Refactors xtemplate's app/config machinery so automatically reloading template sources (filesystem watching, git polling, …) are built on top of a shared, generic config loader with a simple, agnostic reload primitive: a send on a channel on `xtemplate.Config.Reload`.

It also extracts file-watching out of the core `app` package into its own `watchfs` app, and adds a new `git` app that serves templates from a git repository by polling and shallow-cloning the configured repo. The `git` app relies on the presence of the `git` cli; bare repos, using a git library for single-binary deployments (go-git), fetching triggered by web hook, etc are left for future enhancements if they are needed.

Closes #46 (load templates from a git repo)
Closes #63 (non-file template sources)
Supersedes #67 (NATS/backends PR). A NATS-based backend can now be implemented cleanly under app/nats and cmd/nats.

### Motivation

Previously, `app.Main` hard-coded directory watching and conflated CLI parsing, JSON merging, server startup, and the fs-watch loop into one function. Making the template source more general meant these concerns needed to be split up.

## Changes

- **`Config.Reload <-chan []Option`** (`config.go`, `server.go`): when set, `Server` spawns a goroutine that calls `server.Reload(opts...)` on each receive, respecting `Ctx` cancellation and channel close. Options apply per-reload to a copy of the config (not sticky).
- Split `app.Main` into reusable **`LoadConfig[T Configurable]`** (generic, two-pass CLI/JSON merge with documented precedence: CLI flags > JSON CLI > JSON file > defaults) and **`Serve`**.
- New **`Configurable` interface** lets downstream apps embed `app.Config` and while preserving `LoadConfig` behavior in their own app.
- Removed the watch-specific fields and the bespoke `mergeConfig` from core `app`.

## New apps
- **`app/watchfs`** (`cmd/watchfs`): the previous default behavior — watches the templates dir (plus extra `--watch` dirs) and reloads via `Config.Reload`. This behavior is still the default CLI.
- **`app/git`** (`cmd/git`): serves a site from a git repo. Starts immediately with an empty in-memory FS, polls `git ls-remote` on an interval (`--git-interval`, default 15s), shallow-clones on change, and swaps templates via `WithTemplateFS`. Shells out to the `git` binary (no new dependency) and retains the two most recent clones while old instances drain.