### PR TITLE
Add support for custom HTTP handlers

### DIFF
--- a/.config/mise/lib.nu
+++ b/.config/mise/lib.nu
@@ -63,12 +63,17 @@ export def xt-image-tags []: nothing -> list<string> {
     }
 }
 
-# Create a working/log directory for one test run, grouped under dist/runs/ and
-# prefixed with a sortable timestamp so runs list in chronological order (newest
-# last). Maintains a `latest-<target>` symlink and prunes all but the newest few
-# runs per target. Returns the new directory path.
+# Create a working/log directory for one test run, grouped under dist/_runs/
+# and prefixed with a sortable timestamp so runs list in chronological order
+# (newest last). Maintains a `latest-<target>` symlink and prunes all but the
+# newest few runs per target. Returns the new directory path.
+#
+# The dir is named with a leading underscore (dist/_runs) so the Go toolchain
+# ignores it: `go test ./...` and `golangci-lint run ./...` skip directories
+# whose names begin with `.` or `_`. Without that, those tree walks race with
+# the concurrent create/delete churn here when run in parallel under `ci`.
 export def new-run-dir [target: string]: nothing -> string {
-    let runs = ($env.DIST_DIR | path join runs)
+    let runs = ($env.DIST_DIR | path join _runs)
     mkdir $runs
 
     let stamp = (date now | format date '%Y%m%d-%H%M%S')
@@ -135,20 +140,20 @@ export def run-hurl [port: int, report: string] {
 }
 
 # Copy an example app's directory (examples/<name>/) into a fresh run dir under
-# dist/runs and return its path, so integration runs get a clean working copy
+# dist/_runs and return its path, so integration runs get a clean working copy
 # (fresh sqlite, etc.) and can run in parallel without stepping on each other.
-# Mirrors new-run-dir. Keeps only the 5 newest runs per example.
+# Mirrors new-run-dir (including the `_runs` name that keeps the Go toolchain
+# out of these dirs). Keeps only the 5 newest runs per example.
 export def new-example-dir [name: string]: nothing -> string {
-    let runs = ($env.DIST_DIR | path join runs)
+    let runs = ($env.DIST_DIR | path join _runs)
     mkdir $runs
     let stamp = (date now | format date '%Y%m%d-%H%M%S')
     let dir = ($runs | path join $"($stamp)-example-($name)")
     ^cp -r ($env.ROOT | path join examples $name) $dir
-    # Trim the working copy to what a test run actually needs (it runs the
-    # prebuilt binary): drop any *.sqlite a dev session left behind so each run
-    # starts from an empty database, and drop Go sources so copies under dist/
-    # don't get picked up by `golangci-lint run ./...`.
-    glob $"($dir)/**/*.sqlite*" | append (glob $"($dir)/**/*.go") | each { |f| rm -f $f }
+    # Drop any *.sqlite a dev session left behind so each run starts from an
+    # empty database. (The copied Go sources can stay: dist/_runs is invisible
+    # to `go test ./...` and `golangci-lint run ./...` thanks to the `_` prefix.)
+    glob $"($dir)/**/*.sqlite*" | each { |f| rm -f $f }
     ^ln -sfn $dir ($runs | path join $"latest-example-($name)")
     glob $"($runs)/[0-9]*-example-($name)" | sort | reverse | skip 5 | each { |old| rm -rf $old }
     $dir

--- a/.config/mise/tasks/examples
+++ b/.config/mise/tasks/examples
@@ -16,7 +16,7 @@ base="${1:-9000}"
 root="${MISE_PROJECT_ROOT:-$(git rev-parse --show-toplevel)}"
 dist="$root/dist"
 xt="$dist/xtemplate"
-logs="$dist/runs/examples-logs"
+logs="$dist/_runs/examples-logs"
 mkdir -p "$logs"
 
 pids=()

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 go.work*
+dist
 Dockerfile
 .dockerignore
 .gitignore

--- a/app/app.go
+++ b/app/app.go
@@ -143,7 +143,7 @@ func Main(overrides ...xtemplate.Option) {
 	// then re-parse the CLI over the decoded result so flags win over JSON.
 	{
 		arg.MustParse(&config)
-		config.Defaults()
+		config.SetDefaults()
 
 		level := config.LogLevel
 		log = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(level)}))

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -18,7 +18,7 @@ func parseCLI(t *testing.T, argv []string) Args {
 	if err := p.Parse(argv); err != nil {
 		t.Fatalf("failed to parse %v: %v", argv, err)
 	}
-	cfg.Defaults()
+	cfg.SetDefaults()
 	return cfg
 }
 

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -49,7 +49,7 @@ func (m *XTemplateModule) Provision(ctx caddy.Context) error {
 	log := slog.New(zapslog.NewHandler(ctx.Logger().Core())).WithGroup("xtemplate-caddy")
 
 	m.Logger = log
-	m.Defaults()
+	m.SetDefaults()
 	m.Ctx, m.cancel = context.WithCancel(ctx.Context)
 
 	// Resolve any `xtemplate.funcs.*` modules into template FuncMaps and pass

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ func New() (c *Config) {
 
 type Config struct {
 	// The path to the templates directory within the filesystem. Default `templates`.
-	TemplatesDir string `json:"templates_dir,omitempty" arg:"-t,--template-dir" default:"templates"`
+	TemplatesDir string `json:"templates_dir,omitempty" arg:"-t,--template-dir,--templates-dir" default:"templates"`
 
 	// The FS to load templates from. Default: a FS made from the current working directory.
 	TemplatesFS afero.Fs `json:"-" arg:"-"`

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ import (
 
 func New() (c *Config) {
 	c = &Config{}
-	c.Defaults()
+	c.SetDefaults()
 	return
 }
 
@@ -68,7 +68,7 @@ type CrossOriginConfig struct {
 }
 
 // FillDefaults sets default values for unset fields
-func (config *Config) Defaults() *Config {
+func (config *Config) SetDefaults() *Config {
 	if config.TemplatesDir == "" {
 		config.TemplatesDir = "templates"
 	}

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net/http"
 
 	"github.com/spf13/afero"
 )
@@ -53,12 +54,23 @@ type Config struct {
 	// Additional functions to add to the template execution context.
 	FuncMaps []template.FuncMap `json:"-" arg:"-"`
 
+	// Custom HTTP handlers, mounted on the router alongside template and static
+	// file routes. Registered on every instance, so they survive reloads.
+	Handlers []HandlerRoute `json:"-" arg:"-"`
+
 	// The instance context that is threaded through dot providers and can
 	// cancel the server. Defaults to `context.Background()`.
 	Ctx context.Context `json:"-" arg:"-"`
 
 	// The default logger. Defaults to `slog.Default()`.
 	Logger *slog.Logger `json:"-" arg:"-"`
+}
+
+// HandlerRoute pairs a ServeMux pattern with an http.Handler.
+type HandlerRoute struct {
+	// Pattern uses net/http.ServeMux syntax (e.g. "POST /foo/{bar}").
+	Pattern string
+	Handler http.Handler
 }
 
 type CrossOriginConfig struct {
@@ -135,6 +147,18 @@ func WithLogger(logger *slog.Logger) Option {
 func WithFuncMaps(fm ...template.FuncMap) Option {
 	return func(c *Config) error {
 		c.FuncMaps = append(c.FuncMaps, fm...)
+		return nil
+	}
+}
+
+// WithHandler adds a custom HTTP handler at pattern (net/http.ServeMux syntax,
+// e.g. "POST /hook").
+func WithHandler(pattern string, h http.Handler) Option {
+	return func(c *Config) error {
+		if h == nil {
+			return fmt.Errorf("nil handler for pattern %q", pattern)
+		}
+		c.Handlers = append(c.Handlers, HandlerRoute{pattern, h})
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ func TestConfigMinifyDefault(t *testing.T) {
 	// Defaults() must default an unset (nil) Minify to true, so the documented
 	// default holds regardless of construction path (not just via New()).
 	c := &Config{}
-	c.Defaults()
+	c.SetDefaults()
 	if c.Minify == nil || !*c.Minify {
 		t.Error("Defaults() should default an unset Minify to true")
 	}
@@ -22,7 +22,7 @@ func TestConfigMinifyDefault(t *testing.T) {
 	// could never be disabled via the Go API.
 	explicitFalse := false
 	c = &Config{Minify: &explicitFalse}
-	c.Defaults()
+	c.SetDefaults()
 	if c.Minify == nil || *c.Minify {
 		t.Error("Defaults() must not clobber an explicit Minify=false")
 	}

--- a/instance.go
+++ b/instance.go
@@ -114,6 +114,15 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 		return nil, nil, nil, fmt.Errorf("error scanning files: %w", err)
 	}
 
+	for _, route := range build.config.Handlers {
+		pattern, handler := route.Pattern, route.Handler
+		if err := catch(fmt.Sprintf("add custom handler to servemux '%s'", pattern), func() { build.router.Handle(pattern, handler) }); err != nil {
+			return nil, nil, nil, err
+		}
+		build.routes = append(build.routes, InstanceRoute{pattern, handler})
+		build.Routes += 1
+	}
+
 	dcInstance := dotXProvider{build.Instance}
 	dcReq := dotReqProvider{}
 	dcResp := dotRespProvider{}

--- a/instance.go
+++ b/instance.go
@@ -58,7 +58,7 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 
 	build := &builder{
 		Instance: &Instance{
-			config: *config.Defaults(),
+			config: *config.SetDefaults(),
 			id:     nextInstanceIdentity.Add(1),
 		},
 		InstanceStats: &InstanceStats{},

--- a/instance_test.go
+++ b/instance_test.go
@@ -189,6 +189,35 @@ func TestServeHTTP_DirProvider(t *testing.T) {
 	}
 }
 
+func TestServer_EmptyFSWithHandler(t *testing.T) {
+	// xtemplate must build from an empty FS (zero routes) so a server can start
+	// before its templates are available, and custom handlers must still serve.
+	hit := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	cfg := New()
+	server, err := cfg.Server(
+		WithTemplateFS(afero.NewMemMapFs()),
+		WithHandler("POST /hook", handler),
+	)
+	if err != nil {
+		t.Fatalf("failed to build server from empty FS: %v", err)
+	}
+	defer server.Stop()
+
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/hook", nil))
+	if !hit {
+		t.Error("custom handler was not invoked")
+	}
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
 func TestServer_Lifecycle(t *testing.T) {
 	fs := newMemFS(t, map[string]string{
 		"index.html": "INDEX-MARKER",

--- a/server.go
+++ b/server.go
@@ -30,7 +30,7 @@ type Server struct {
 
 // Build creates a new Server from an xtemplate.Config.
 func (config Config) Server(cfgs ...Option) (*Server, error) {
-	if _, err := config.Defaults().Options(cfgs...); err != nil {
+	if _, err := config.SetDefaults().Options(cfgs...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds a way to register custom `http.Handler`s alongside xtemplate's template and static-file routes, plus a couple of related cleanups.

## Changes

- **Custom handlers** New `Config.Handlers` field and `WithHandler(pattern, h)` option. Handlers use `net/http.ServeMux` pattern syntax (e.g. `"POST /hook"`) and are registered on every instance, so they survive reloads.
- **`--templates-dir` flag**. Added as an alias for the existing `--template-dir` CLI flag.
- **Rename** `Config.Defaults` → `Config.SetDefaults` for clarity (the method mutates and returns the config).
- **Rename** `dist/runs` → `dist/_runs` to avoid racing Go tooling in CI.

## Notes

- `WithHandler` rejects a nil handler with an error.
- `Config.Defaults` → `SetDefaults` is a **breaking change** for any external callers of the exported method.
