### PR TITLE
CI Polish

### DIFF
--- a/.config/mise/tasks/dist
+++ b/.config/mise/tasks/dist
@@ -3,7 +3,7 @@
 use ../lib.nu *
 cd $env.ROOT
 
-let ver = (xt-version)
+let ver = (let v = (xt-version); if ($v | is-empty) { ^git -C $env.ROOT describe --tags --match 'v*' | str trim } else { $v })
 # -w omits the DWARF symbol table. On darwin this avoids a slow Mach-O
 # post-edit step that embeds DWARF into the binary (Go issue #12259).
 # Release binaries don't need debug info, so strip it on all platforms.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # Full history + tags so `git describe` can derive the version.
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
         run: mise run push-docker
 
       - name: Archive test results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: logs
@@ -57,17 +57,17 @@ jobs:
             dist/**/*.log
             dist/**/report/
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: xtemplate-amd64-linux
           path: "dist/xtemplate-amd64-linux/*"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: xtemplate-amd64-darwin
           path: "dist/xtemplate-amd64-darwin/*"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: xtemplate-amd64-windows
           path: "dist/xtemplate-amd64-windows/*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,20 +57,9 @@ jobs:
             dist/**/*.log
             dist/**/report/
 
-      - uses: actions/upload-artifact@v7
+      - uses: infogulch/upload-artifacts@v1
         with:
-          name: xtemplate-amd64-linux
-          path: "dist/xtemplate-amd64-linux/*"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: xtemplate-amd64-darwin
-          path: "dist/xtemplate-amd64-darwin/*"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: xtemplate-amd64-windows
-          path: "dist/xtemplate-amd64-windows/*"
+          path: "dist/*.zip"
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+CI Polish
+
 - Bump remaining GitHub action versions, fixes build warnings
 - Upload dist zips via `infogulch/upload-artifacts@v1`
+- Dist zips are versioned with git describe when running ci on a non-tagged commit
 
 ## [v0.9.3] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump remaining GitHub action versions, fixes build warnings
+
 ## [v0.9.3] - 2026-06-22
 
 - Bump GitHub action versions, fixes release ci workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Bump remaining GitHub action versions, fixes build warnings
+- Upload dist zips via `infogulch/upload-artifacts@v1`
 
 ## [v0.9.3] - 2026-06-22
 


### PR DESCRIPTION
Changes:

- Bump remaining GitHub action versions, fixes build warning
- Upload dist zips via [infogulch/upload-artifacts@v1](https://github.com/infogulch/upload-artifacts)
- Dist zips are versioned with git describe when running ci on a non-tagged commit