### PR TITLE
Drop withArgs, polish examples, and add an SSE test harness (0.9.6)

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -11,6 +11,7 @@ hurl = "latest"
 "aqua:nushell/nushell" = "latest"
 golangci-lint = "latest"
 "go:github.com/caddyserver/xcaddy/cmd/xcaddy" = "latest"
+"github:lightpanda-io/browser" = "nightly"
 
 [tasks.lint]
 description = "Run lint checks"

--- a/.config/mise/eventsource-polyfill.js
+++ b/.config/mise/eventsource-polyfill.js
@@ -1,0 +1,28 @@
+// EventSource polyfill for lightpanda, which does not implement EventSource.
+// Uses fetch + ReadableStream (both supported) to replicate the SSE protocol.
+class EventSource {
+    constructor(url) {
+        this.onmessage = null;
+        const u = new URL(url, location.href);
+        fetch(u, { headers: { Accept: "text/event-stream" } })
+            .then(async (r) => {
+                const reader = r.body.getReader();
+                const dec = new TextDecoder();
+                let buf = "";
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    buf += dec.decode(value);
+                    const lines = buf.split("\n");
+                    buf = lines.pop(); // hold back any incomplete trailing line
+                    for (const line of lines) {
+                        if (line.startsWith("data:") && this.onmessage) {
+                            this.onmessage({ data: line.slice(5).trim() });
+                        }
+                    }
+                }
+            })
+            .catch((e) => console.error("eventsource-polyfill:", String(e)));
+    }
+    close() {}
+}

--- a/.config/mise/lib.nu
+++ b/.config/mise/lib.nu
@@ -170,6 +170,39 @@ export def run-example [port: int, dir: string] {
     ^hurl --continue-on-error --no-output --test --report-html $report --connect-to $"localhost:8080:localhost:($port)" ...(glob $"($dir)/tests/*.hurl")
 }
 
+# Test a page that uses SSE with lightpanda.
+#
+# lightpanda does not implement EventSource, so this injects a fetch-based
+# polyfill (.config/mise/eventsource-polyfill.js) before any page scripts run.
+# The polyfill replaces `new EventSource(url)` with a streaming fetch that fires
+# onmessage for each `data:` line, letting the page update the DOM normally.
+# --wait-selector fires as soon as the first matching element appears, so the
+# stream can still be running in the background when the snapshot is taken.
+#
+# --selector    CSS selector to wait for before capturing the DOM
+# --contains    assert this substring appears in the final HTML (optional)
+# --wait-ms     max milliseconds to wait for --selector (default: 5000)
+export def run-lightpanda-sse [
+    url: string,
+    --selector: string = "body",
+    --contains: string = "",
+    --wait-ms: int = 5000,
+] {
+    let port = ($url | url parse | get port | into int)
+    wait-ready $port 30
+    let polyfill = ($env.ROOT | path join .config mise eventsource-polyfill.js)
+    let html = (^lightpanda fetch
+        --inject-script-file $polyfill
+        --wait-selector $selector
+        --wait-ms ($wait_ms | into string)
+        --dump html
+        $url
+    )
+    if ($contains | is-not-empty) and not ($html | str contains $contains) {
+        error make --unspanned { msg: $"lightpanda-sse: expected '($contains)' in DOM\n($html)" }
+    }
+}
+
 # List external dep packages for the current platform, configured by setting
 # GOOS/GOARCH in the environment. Uses -deps -test ./... to include packages
 # imported by test files in this module, so gotest doesn't need to recompile

--- a/.config/mise/tasks/test-example-sse-chat
+++ b/.config/mise/tasks/test-example-sse-chat
@@ -10,7 +10,10 @@ let server = (job spawn {
     ^$bin --loglevel -4 --config-file config.json --listen :0 out+err> server.log
 })
 let port = (wait-listen-port ($work | path join server.log))
-let outcome = (try { run-example $port $work; "ok" } catch { |e| $e.msg })
+let outcome = (try {
+    run-lightpanda-sse $"http://localhost:($port)/?count=3&delay=10" --selector "#feed li" --contains "message 3"
+    "ok"
+} catch { |e| $e.msg })
 job kill $server
 if $outcome != "ok" {
     print -e $"test-example-sse-chat failed: ($outcome)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drop withArgs, use list instead
 - Convert hub examples list from js to a Go template equivalent
+- Add a nushell-based SSE test harness
 
 ## [v0.9.5] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Drop withArgs, use list instead
+- Convert hub examples list from js to a Go template equivalent
 
 ## [v0.9.5] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop withArgs, use list instead
+
 ## [v0.9.5] - 2026-06-23
 
 Pre-compress static files.

--- a/dot_test.go
+++ b/dot_test.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
-	"text/template"
 )
 
 type testGreeting struct {
@@ -142,56 +140,6 @@ func TestDotValuePartialCleanup(t *testing.T) {
 	if rec.gotErr == nil {
 		t.Error("expected the construction error to be passed to Cleanup")
 	}
-}
-
-// TestWithArgsOnRealDot exercises withArgs against a dot built by makeDot and
-// executed through text/template, covering both wrapping the whole dot and
-// scoping down to a single promoted field.
-func TestWithArgsOnRealDot(t *testing.T) {
-	d, err := makeDot([]DotConfig{testDotProvider{field: "Greeter"}})
-	if err != nil {
-		t.Fatalf("makeDot: %v", err)
-	}
-	val, err := d.value(context.Background(), httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
-	if err != nil {
-		t.Fatalf("dot.value: %v", err)
-	}
-	dot := val.Interface()
-
-	render := func(t *testing.T, text string, data any) (string, error) {
-		t.Helper()
-		tmpl, err := template.New("t").Funcs(xtemplateFuncs).Parse(text)
-		if err != nil {
-			t.Fatalf("parse: %v", err)
-		}
-		var sb strings.Builder
-		err = tmpl.Execute(&sb, data)
-		return sb.String(), err
-	}
-
-	t.Run("wrap whole dot: fields stay promoted, Args added", func(t *testing.T) {
-		got, err := render(t, `{{template "sub" withArgs . "title"}}{{define "sub"}}{{.Args | idx 0}}:{{.Greeter.Greeting}}{{end}}`, dot)
-		if err != nil {
-			t.Fatalf("execute: %v", err)
-		}
-		if want := "title:hi"; got != want {
-			t.Errorf("rendered %q, want %q", got, want)
-		}
-	})
-
-	t.Run("wrap a single field: its members promote, others error", func(t *testing.T) {
-		got, err := render(t, `{{$a := withArgs .Greeter "foo"}}{{$a.Greeting}}:{{$a.Args | idx 0}}`, dot)
-		if err != nil {
-			t.Fatalf("execute: %v", err)
-		}
-		if want := "hi:foo"; got != want {
-			t.Errorf("rendered %q, want %q", got, want)
-		}
-
-		if _, err := render(t, `{{$a := withArgs .Greeter "foo"}}{{$a.Greeter}}`, dot); err == nil {
-			t.Error("expected an error accessing a field not present on the wrapped value")
-		}
-	})
 }
 
 func TestMakeDotNilProvider(t *testing.T) {

--- a/examples/blog/templates/posts/{slug}.html
+++ b/examples/blog/templates/posts/{slug}.html
@@ -1,33 +1,28 @@
-{{- define "head"}}
-<head>
-<meta charset="utf-8">
-<title>{{.Args | idx 0}}</title>
-{{- with $hash := .X.StaticFileHash `/assets/style.css`}}
-<link rel="stylesheet" href="/assets/style.css?hash={{$hash}}" integrity="{{$hash}}">
-{{- end}}
-</head>
-{{end}}
-{{- $file := print (.Req.PathValue `slug`) `.md` -}}
-{{- if not (.Posts.Exists $file)}}
 <!DOCTYPE html>
 <html lang="en">
-{{- template "head" withArgs . "Post not found"}}
+{{- $file := print (.Req.PathValue `slug`) `.md`}}
+{{- if not (.Posts.Exists $file)}}
+{{- block "head" list . "Post not found"}}
+<head>
+<meta charset="utf-8">
+<title>{{. | idx 1}}</title>
+{{- $hash := (. | idx 0).X.StaticFileHash "/assets/style.css"}}
+<link rel="stylesheet" href="/assets/style.css{{$hash}}" integrity="{{$hash}}">
+</head>
+{{- end}}
 <body>
 <h1>Post not found</h1>
 <p><a href="/">Back home</a></p>
 </body>
 </html>
 {{- .Resp.ReturnStatus 404}}
-{{- end}}
+{{- else }}
 {{- $post := markdown (.Posts.Read $file)}}
-<!DOCTYPE html>
-<html lang="en">
-{{- template "head" withArgs . $post.Meta.title}}
+{{- template "head" list . $post.Meta.title}}
 <body>
 <h1>{{$post.Meta.title}}</h1>
-{{- with $post.Meta.date}}
-<p><em>{{.}}</em></p>
-{{- end}}
+<p><em>{{$post.Meta.date}}</em></p>
 {{$post.Body}}
 </body>
+{{- end}}
 </html>

--- a/examples/hub/templates/.shared.html
+++ b/examples/hub/templates/.shared.html
@@ -1,0 +1,5 @@
+{{- define "link"}}
+{{- $href := . | idx 1 }}
+{{- $hash := (. | idx 0).StaticFileHash $href }}
+<link href="{{ $href }}?hash={{ $hash }}" integrity="{{ $hash }}"{{range $pair := slice . 2 | chunk 2}} {{$pair | idx 0 | trustAttr}}="{{$pair | idx 1}}"{{end}}/>
+{{- end}}

--- a/examples/hub/templates/index.html
+++ b/examples/hub/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>xtemplate examples</title>
-  <link rel="stylesheet" href="/assets/app.css">
+  {{ template "link" list .X "/assets/app.css" "rel" "stylesheet" }}
   <style>
     .cards { list-style: none; padding: 0; display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)); }
     .cards a { display: block; height: 100%; padding: 1rem 1.25rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); text-decoration: none; color: inherit; }
@@ -16,37 +16,24 @@
 <body>
   <h1>xtemplate examples</h1>
   <p>Each example runs on its own port. Click one to open it.</p>
-  <ul class="cards" id="cards"></ul>
-  <script>
-    // Each example listens at the hub's port plus its offset. Derive the links
-    // from this page's own port so they're correct no matter what base port the
-    // `examples` task was started with.
-    const examples = [
-      [1, "Contacts", "File routing, custom method routes, and DB CRUD (sqlite)."],
-      [2, "SSE chat", "Live updates streamed with Server-Sent Events and .Flush."],
-      [3, "Blog", "Content-hashed asset URLs and Subresource Integrity."],
-      [4, "File browser", "Listing and reading files via the FS context provider."],
-      [5, "Embedded", "Single-binary deployment with //go:embed."],
-      [6, "Custom DotProvider", "Exposing Go code to templates (the repository pattern)."],
-    ];
-    const base = parseInt(location.port || "9000", 10);
-    const list = document.getElementById("cards");
-    for (const [offset, name, desc] of examples) {
-      const port = base + offset;
-      const li = document.createElement("li");
-      const a = document.createElement("a");
-      a.href = location.protocol + "//" + location.hostname + ":" + port;
-      const tag = document.createElement("span");
-      tag.className = "port";
-      tag.textContent = ":" + port;
-      const h2 = document.createElement("h2");
-      h2.textContent = name;
-      const p = document.createElement("p");
-      p.textContent = desc;
-      a.append(tag, h2, p);
-      li.appendChild(a);
-      list.appendChild(li);
-    }
-  </script>
+  {{- $host := .Req.Host | splitList ":" | first }}
+  {{- $port := .Req.Host | splitList ":" | last | default "80" | atoi }}
+  {{- $examples := list
+      (list "Contacts" "File routing, custom method routes, and DB CRUD (sqlite).")
+      (list "SSE chat" "Live updates streamed with Server-Sent Events and .Flush.")
+      (list "Blog" "Content-hashed asset URLs and Subresource Integrity.")
+      (list "File browser" "Listing and reading files via the FS context provider.")
+      (list "Embedded" "Single-binary deployment with //go:embed.")
+      (list "Custom DotProvider" "Exposing Go code to templates (the repository pattern).")
+  }}
+  <ul class="cards" id="cards">
+    {{- range $i, $example := $examples }}
+    <li class="card"><a href="//{{ $host }}:{{ add $port $i 1 }}/">
+        <span class="port">{{ add $port $i 1 }}</span>
+        <h2>{{ $example | idx 0 }}</h2>
+        <p>{{ $example | idx 1 }}</p></a>
+    </li>
+    {{- end }}
+  </ul>
 </body>
 </html>

--- a/examples/sse-chat/templates/index.html
+++ b/examples/sse-chat/templates/index.html
@@ -4,13 +4,17 @@
 <h1>Live feed</h1>
 <ul id="feed"></ul>
 <script>
-    new EventSource("/events").onmessage = (e) => {
+    new EventSource("/events?count=3&delay=200").onmessage = (e) => {
         const li = document.createElement("li");
         li.textContent = e.data;
         document.getElementById("feed").appendChild(li);
     };
 </script>
-{{- define "SSE /events"}} {{- $count := .Req.URL.Query.Get `count` | default
-`20` | atoi}} {{- $delay := .Req.URL.Query.Get `delay` | default `1000` | atoi}}
-{{- range $i := .Flush.Repeat $count}} {{- printf "data: message %d\n\n"
-$i}}{{$.Flush.Flush}}{{$.Flush.Sleep $delay}} {{- end}} {{- end}}
+{{- define "SSE /events"}}
+{{- $count := .Req.URL.Query.Get `count` | default `20` | atoi}}
+{{- $delay := .Req.URL.Query.Get `delay` | default `1000` | atoi}}
+{{- range $i := .Flush.Repeat $count}}
+    {{- $.Flush.SendSSE "" (printf "message %d" $i)}}
+    {{- $.Flush.Sleep $delay}}
+{{- end}}
+{{- end}}

--- a/funcs.go
+++ b/funcs.go
@@ -34,7 +34,6 @@ var xtemplateFuncs template.FuncMap = template.FuncMap{
 	"trustSrcSet":  FuncTrustSrcSet,
 	"idx":          FuncIdx,
 	"try":          FuncTry,
-	"withArgs":     FuncWithArgs,
 }
 
 // blueMondayPolicies is the map of names of bluemonday policies available to
@@ -318,61 +317,6 @@ func FuncTry(fn any, args ...any) (*result, error) {
 		Value: value,
 		Error: err,
 	}, nil
-}
-
-// withArgs attaches extra arguments to the dot value so they can be passed to a
-// sub-template, working around Go's restriction that the {{template}} action
-// accepts only a single data argument. It returns a wrapper struct that embeds
-// the original dot (so all of its fields and methods remain accessible) and
-// exposes the extra arguments as a .Args slice. For example:
-//
-//	{{template "head" withArgs . "Post not found"}}
-//
-// and inside the "head" template:
-//
-//	<title>{{.Args | idx 0}}</title>
-//	{{.X.StaticFileHash "/assets/style.css"}}
-//
-// Calling withArgs on an already-wrapped dot replaces .Args rather than nesting,
-// keeping the embedded dot flat. The dot must be a struct.
-func FuncWithArgs(dot any, args ...any) (any, error) {
-	dv := reflect.ValueOf(dot)
-	if dv.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("withArgs: dot is %T, want a struct", dot)
-	}
-	var dat reflect.Type
-	if isWithArgs(dv.Type()) {
-		// Already a withArgs wrapper: reuse its type and unwrap the embedded
-		// dot so repeated calls replace Args instead of nesting Dot.Dot.Dot.
-		dat = dv.Type()
-		dv = dv.FieldByName("Dot")
-	} else {
-		fields := []reflect.StructField{
-			{Name: "Dot", Type: dv.Type(), Anonymous: true},
-			{Name: "Args", Type: reflect.TypeFor[[]any]()},
-		}
-		dat = reflect.StructOf(fields)
-	}
-	dav := reflect.New(dat).Elem()
-	dav.FieldByName("Dot").Set(dv)
-	dav.FieldByName("Args").Set(reflect.ValueOf(args))
-	return dav.Interface(), nil
-}
-
-// isWithArgs reports whether t is a wrapper struct produced by FuncWithArgs,
-// identified by its exact signature: an embedded "Dot" field plus an
-// "Args []any" field. This avoids mistaking an arbitrary user struct that
-// merely happens to have a field named "Dot" for an already-wrapped dot.
-func isWithArgs(t reflect.Type) bool {
-	if t.Kind() != reflect.Struct {
-		return false
-	}
-	dot, ok := t.FieldByName("Dot")
-	if !ok || !dot.Anonymous {
-		return false
-	}
-	args, ok := t.FieldByName("Args")
-	return ok && args.Type == reflect.TypeFor[[]any]()
 }
 
 type result struct {

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -2,10 +2,8 @@ package xtemplate
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -199,57 +197,4 @@ func TestFuncIdx(t *testing.T) {
 	if _, err := FuncIdx(0, 42); err == nil {
 		t.Errorf("FuncIdx(0, 42) expected a non-indexable error, got nil")
 	}
-}
-
-func TestFuncWithArgs(t *testing.T) {
-	type data struct{ Name string }
-
-	t.Run("non-struct errors", func(t *testing.T) {
-		if _, err := FuncWithArgs(42, "a"); err == nil {
-			t.Error("expected an error for non-struct dot")
-		}
-	})
-
-	t.Run("user struct with a Dot field is wrapped, not rewrapped", func(t *testing.T) {
-		// A struct that happens to have a field named "Dot" but no Args field
-		// must not be mistaken for an existing wrapper (which used to panic).
-		type bad struct{ Dot int }
-		got, err := FuncWithArgs(bad{Dot: 5}, "a")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !isWithArgs(reflect.TypeOf(got)) {
-			t.Errorf("expected %T to be a fresh withArgs wrapper", got)
-		}
-	})
-
-	t.Run("rewrap replaces args without nesting", func(t *testing.T) {
-		w1, err := FuncWithArgs(data{Name: "x"}, "a")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		w2, err := FuncWithArgs(w1, "b")
-		if err != nil {
-			t.Fatalf("unexpected error on rewrap: %v", err)
-		}
-		if got, want := fmt.Sprintf("%T", w1), fmt.Sprintf("%T", w2); got != want {
-			t.Errorf("rewrap changed type: %s vs %s (Dot should stay flat)", got, want)
-		}
-	})
-
-	t.Run("promotes embedded fields and exposes Args in templates", func(t *testing.T) {
-		wrapped, err := FuncWithArgs(data{Name: "world"}, "hello")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		tmpl := template.Must(template.New("t").Funcs(xtemplateFuncs).
-			Parse(`{{.Args | idx 0}} {{.Name}}`))
-		var sb strings.Builder
-		if err := tmpl.Execute(&sb, wrapped); err != nil {
-			t.Fatalf("execute: %v", err)
-		}
-		if got, want := sb.String(), "hello world"; got != want {
-			t.Errorf("rendered %q, want %q", got, want)
-		}
-	})
 }


### PR DESCRIPTION
- Remove `withArgs` template. func `list` covers the same ground with less code and complexity.
  - Slightly breaking: replaces `withArgs` usages with `list` (see `examples/blog/templates/posts/{slug}.html`).
- Convert hub examples index from JS to Go templates. Server-rendered list instead of client-side JS.
- Add an SSE test harness. Mise task + `eventsource-polyfill.js` so SSE pages like `examples/sse-chat` can be exercised end-to-end. Clean up `examples/sse-chat` template.