### PR TITLE
Created bounded context glossary & align docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,83 @@
+# xtemplate
+
+A server-side HTML templating engine that extends `html/template` with a per-request dot context populated by pluggable data providers, so a directory of templates can define an entire application.
+
+## Language
+
+### Server & lifecycle
+
+**Server**:
+The long-lived, reloadable request handler that owns the current instance and routes incoming requests to it. One server exists per running xtemplate and persists, while the instance it points to may be replaced.
+
+**Reload**:
+A server operation that builds a fresh instance from the same config (re-reading the template root, re-parsing templates, re-initializing providers) and atomically swaps it in as the current instance. In-flight requests finish on the old instance, new requests use the new one, and the old instance's context is cancelled so there's no process restart and no dropped requests.
+
+**Instance**:
+A fully-loaded, immutable snapshot of a template root that serves HTTP requests. Instances are built once at startup (or on reload) and swapped atomically; a running instance is never mutated. The instance itself is exposed to templates as the `.X` dot field.
+
+**Template root**:
+The directory of template files that defines an application, backed by an `fs.FS`. Loaded recursively at startup; every `.html` file becomes invocable by its path relative to this root (e.g. `/admin/settings.html`), and files map to routes based on their path.
+
+### Templates & execution
+
+**Template**:
+A single named, parsed unit in an instance's template namespace. Every template gets its name one of two ways, and the name determines how it can be reached:
+
+- **Path template** — named after its path in the template root (e.g. `/admin/settings.html`), parsed from the whole content of a file matching the configured extension (default `.html`). Its path derives an implicit `GET` route.
+- **Define template** — named by an explicit `{{define "..."}}` block. If the name matches a method + path pattern (e.g. `POST /contact`), the name itself is the route; otherwise it is a reusable template invoked by name from other templates.
+
+_Avoid_: partial, sub-template, template block, template file, named template definition
+
+**Initialization template**:
+A template whose name begins with `INIT ` that xtemplate executes once when an instance is built, before it serves any request, rather than in response to a route. Used for one-time setup such as seeding a database. Its rendered output is discarded, and an error aborts the build.
+_Avoid_: template initializer, INIT template
+
+**Dot context** (or **dot**):
+The single value passed as `.` to every template execution for a request. It is a struct assembled per-request whose fields are contributed by dot providers (builtin ones like `.X`, `.Req`, `.Resp`, `.Flush`, plus any configured or custom providers). By design it is the sole channel through which templates reach request data, response control, and backing data sources; FuncMap functions are non-request-scoped.
+
+**Template function**:
+A function callable from any template (`{{myFunc x}}`), supplied via a FuncMap at startup. Unlike dot providers, functions are stateless and intended for pure computation (formatting, string/data manipulation). Three sets are present by default: Go's builtins, the Sprig library, and xtemplate's own additions.
+
+**Early return**:
+A successful, deliberate halt of a template's execution partway through, as opposed to an error. Triggered by the `return` function and by dot methods such as `.Resp.ReturnStatus` and `.Flush.Sleep`; internally signalled by the `ReturnError` sentinel, which handlers treat as normal completion rather than a failure.
+_Avoid_: abort, halt, ReturnError (as the user-facing name)
+
+### Routing
+
+**Route**:
+A method + path pattern (in `http.ServeMux` syntax) mapped to a handler on an instance's router. Routes come from two sources: path templates, whose file path becomes the pattern (e.g. `admin/settings.html` → `GET /admin/settings`; `index.html` maps to its directory; dotfiles are excluded), and define templates whose name is itself an explicit method + pattern, e.g. `{{define "GET /contact/{id}"}}`. The pseudo-method `SSE` selects a flushing handler.
+
+**Handler**:
+The `http.Handler` that answers a matched route. An instance's router mixes four kinds: **buffered** template handlers (the default; output is buffered so `.Resp` can set status/headers mid-execution and errors abort cleanly), **flushing** template handlers (stream incrementally via `.Flush` for Server-Sent Events; selected by the `SSE` verb in a route name), **static file** handlers (serve non-template files from the template root), and **custom** handlers (user-supplied handlers mounted by pattern).
+
+### Providers
+
+**Dot provider**:
+A component that contributes one named field to the per-request template dot context (`{{.Field}}`). Each dot provider has a field name, a one-time init step, and a per-request value step.
+
+**Dot field**:
+The named struct field a dot provider contributes to the dot context. Its name is chosen by the user (the provider's `FieldName`); two providers may not share a field name within one instance.
+
+**Provider type**:
+The registered name of a provider and the discriminator string in provider JSON (`"type"`) that selects which dot provider constructor to invoke from the registry.
+
+**Builtin provider**:
+A dot provider supplied by xtemplate itself and present by default on relevant requests. Currently: `X` (instance) and `Req` (request) are provided on every request, `Resp` available on buffered handlers, and `Flush` is available on flushing handlers.
+
+**Provider package**:
+Any Go package that self-registers a dot provider type via `init()`.
+
+**Core provider**:
+Provider packages published by xtemplate under `xtemplate/providers`. Currently: `sql`, `fs`, `flags`, `nats`.
+
+**Standard provider set**:
+The set of provider types that are included by default in xtemplate's binary packages. Currently all core providers are included in the binaries under `cmd`. For caddy builds the standard provider set is available by blank-importing `xtemplate/caddy/standard`.
+
+**Custom provider**:
+A dot provider implemented in user Go code and attached to an instance in the `Config.Providers` slice or via `WithProvider`, not appearing in the type registry.
+
+**Provider config**:
+The JSON or Go-API configuration of a dot provider instance: its type, its field name, and its type-specific settings. JSON configs arrive as raw messages and are decoded via the registry; custom provider configs arrive as already-constructed `DotConfig` values.
+
+**Caddyfile provider**:
+A Caddy module in the `xtemplate.providers.*` namespace that implements the `CaddyfileProvider` interface and parses a Caddyfile `provider <type> <field> { }` block into a `json.RawMessage`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ integrity.
 > that immediately starts executing a template reference in response. No slow
 > cascading disk accesses or parsing overhead before you even begin crafting the
 > response.
+
 </details>
 
 <details><summary><strong>🔄 Live reload</strong></summary>
@@ -76,7 +77,7 @@ integrity.
 > <script>new EventSource("/reload").onmessage = () => location.reload()</script>
 > <!-- Maybe not a great idea for production, but you do you. -->
 > ```
->
+
 </details>
 
 <details open><summary><strong>🗃️ Simple file-based routing</strong></summary>
@@ -94,7 +95,7 @@ integrity.
 > └── shared
 >     └── .head.html      (not routed because it starts with '.')
 > ```
->
+
 </details>
 
 <details><summary><strong>🔱 Add custom routes to handle any method and path pattern</strong></summary>
@@ -142,7 +143,7 @@ integrity.
 >   </body>
 > </html>
 > ```
->
+
 </details>
 
 <details><summary><strong>🛡️ XSS safe by default</strong></summary>
@@ -164,15 +165,17 @@ integrity.
 > action you can define by writing a Go API**, like the common "repository"
 > design pattern for example.
 >
-> Modify `Config` to add built-in or custom `ContextProvider` implementations,
-> and they will be made available in the dot context.
+> Add core or custom dot providers to `Config.Providers` (or via
+> `WithProvider`); each implements the `DotConfig` interface and contributes a
+> field to the dot context.
 >
-> Some built-in context providers are listed next:
+> Some core dot providers are listed next:
+
 </details>
 
-<details><summary><strong>💽 Database context provider: Execute queries</strong></summary>
+<details><summary><strong>💽 SQL dot provider: Execute queries</strong></summary>
 
-> Add the built-in Database Context Provider to run queries using the configured
+> Add the SQL dot provider to run queries using the configured
 > Go driver and connection string for your database. (Supports the `sqlite3`
 > driver by default, compile with your desired driver to use it.)
 >
@@ -183,12 +186,12 @@ integrity.
 >   {{end}}
 > </ul>
 > ```
->
+
 </details>
 
-<details><summary><strong>🗄️ Filesystem context provider: List and read local files</strong></summary>
+<details><summary><strong>🗄️ Filesystem dot provider: List and read local files</strong></summary>
 
-> Add the built-in Filesystem Context Provider to List and read
+> Add the filesystem dot provider to list and read
 > files from the configured directory.
 >
 > ```html
@@ -199,18 +202,18 @@ integrity.
 > {{end}}
 > </ol>
 > ```
->
+
 </details>
 
-<details><summary><strong>💬 NATS context provider: Send and receive messages</strong></summary>
+<details><summary><strong>💬 NATS dot provider: Send and receive messages</strong></summary>
 
-> Add and configure the NATS Context Provider to send messages, use the
+> Add and configure the NATS dot provider to send messages, use the
 > Request-Response pattern, and even send live updates to a client.
 >
 > ```html
 > <example></example>
 > ```
->
+
 </details>
 
 <details open><summary><strong>📤 Optimal asset serving</strong></summary>
@@ -237,7 +240,7 @@ integrity.
 > <link rel="stylesheet" href="/reset.css?hash={{$hash}}" integrity="{{$hash}}">
 > {{- end}}
 > ```
->
+
 </details>
 
 <details><summary><strong>📬 Live updates with Server Sent Events (SSE)</strong></summary>
@@ -246,12 +249,14 @@ integrity.
 > SSE requests will be handled by invoking the template. Individual messages can
 > be sent by using `.Flush`, and the template can be paused to wait on messages
 > sent over Go channels or can block on server shutdown.
+
 </details>
 
 <details><summary><strong>🐜 Small footprint</strong></summary>
 
 > Compiles to a ~30MB binary. Easily add your own custom functions and choice of
 > database driver on top.
+
 </details>
 
 <details open><summary><strong>🏃‍♂️‍➡️ Single binary deployments</strong></summary>
@@ -263,7 +268,7 @@ integrity.
 > //go:embed all:templates
 > var Files embed.FS
 > ```
->
+
 </details>
 
 ## 📦 How to run
@@ -430,7 +435,7 @@ configured multiple times with different configurations.
 #### ✏️ Custom dot fields
 
 You can create custom dot fields that expose arbitrary Go functionality to your
-templates. See [👩‍⚕️ Writing a custom `DotProvider`](#-writing-a-custom-dotprovider).
+templates. See [👩‍⚕️ Writing a custom dot provider](#-writing-a-custom-dot-provider).
 
 ### 📐 Functions
 
@@ -471,8 +476,8 @@ xtemplate is split into the following packages:
 - `github.com/infogulch/xtemplate` is a library that exports the `Instance`
   struct which can load template files and implements `http.Handler` that
   routes requests to templates and serves static files, the `Server` struct
-  which can atomically reload an `Instance` on demand, and a number of built-in
-  providers.
+  struct which can atomically reload an `Instance` on demand, and the builtin
+  dot providers (`X`, `Req`, `Resp`, `Flush`).
 - `./app` is a library that contains an exported `Main` function which
   configures and starts xtemplate with CLI args and accepts config override
   parameters. This `Main` fucntion can be used as a reference for using the
@@ -519,7 +524,7 @@ scripts with `nu --ide-check`, `lint-go` runs golangci-lint), `go test`
 (`gotest`), the three integration targets, and then the release `dist` and
 Docker image builds.
 
-### 👩‍⚕️ Writing a custom `DotProvider`
+### 👩‍⚕️ Writing a custom dot provider
 
 Implement the `xtemplate.DotConfig` interface on your type:
 

--- a/build.go
+++ b/build.go
@@ -37,7 +37,7 @@ type InstanceStats struct {
 	Routes                        int
 	TemplateFiles                 int
 	TemplateDefinitions           int
-	TemplateInitializers          int
+	InitializationTemplates       int
 	StaticFiles                   int
 	StaticFilesAlternateEncodings int
 }

--- a/docs/adr/0001-global-init-registry-for-dot-providers.md
+++ b/docs/adr/0001-global-init-registry-for-dot-providers.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+---
+
+# Global `init()` registry for dot providers
+
+Dot providers self-register a `type` string → constructor in a package-level map
+(`xtemplate/providers.go`) from their package `init()`. During config
+resolution, `resolveProviders` peeks the `"type"` discriminator on each JSON
+config entry, looks up the constructor, and re-decodes into the concrete type. A
+binary opts into a provider simply by importing its package, so the linked
+provider set is exactly the import set.
+
+The map is written only from `init()` and read-only afterward. Go runs all
+`init()` functions on a single thread before `main`, so every write
+happens-before any concurrent reader; no races are possible (unless runtime
+registration is ever supported).
+
+## Considered options
+
+- **Explicit, non-global registry** - `Config` holds a `*Registry` and the user
+  calls `Register("nats", ...)` in `main`. Rejected: `xcaddy` generates `main`,
+  so a Caddy user has no place to call `Register`. The global `init()` registry
+  is the only mechanism that fits both the `app.Main` path and the Caddy path,
+  and it mirrors how Caddy's own plugin ecosystem assembles.
+
+## Consequences
+
+- The `"type"` JSON key is reserved by the discriminator. A provider struct with
+  a `json:"type"` string field is silently overwritten with the type string
+  during decode (there is no `DisallowUnknownFields`), so provider configs must
+  not reuse that key. (The Caddyfile path enforces this with an explicit error
+  but the registry decode does not. See ADR-0003.)
+- Provider config errors (unknown `type`, bad settings) surface at instance
+  build time inside `resolveProviders`, not at config-load time.

--- a/docs/adr/0002-uniform-excludable-providers.md
+++ b/docs/adr/0002-uniform-excludable-providers.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+---
+
+# Every dot provider is an excludable package
+
+xtemplate's dot providers live in their own packages at
+`xtemplate/providers/<type>` (`dotsql`, `dotfs`, `dotflags`, `dotnats`) and are
+linked only when a binary imports one. The `xtemplate` package holds no provider
+types, so a binary that never imports a provider never links its dependencies.
+We call the packages xtemplate itself ships **core providers**, but they are
+ordinary provider packages with no special status.
+
+## Considered options
+
+- **Keep db/fs/flags in the `xtemplate` package, move only nats out.** Their
+  dependencies are lightweight (`database/sql` is stdlib; `afero` was already a
+  core dependency), so keeping them in-core wouldn't force heavy linking.
+  Rejected: it creates a two-class system where some providers are excludable
+  and some are not with no principled rule for which class a new provider joins.
+  Moving every provider out erases the classification question entirely; the
+  cost is a few explicit import lines per binary, which double as a manifest of
+  what's linked.
+
+## Consequences
+
+- Breaking Go-API and JSON-config change (pre-1.0, taken as a clean break): the
+  four typed config slices collapse into one `providers` array with a `type`
+  discriminator, and all provider symbols move to their `providers/<type>`
+  packages.
+- Go binaries opt in via explicit per-provider imports, though all the default
+  binary distributions include all core providers. Caddy users can get the
+  standard provider set with the `caddy/standard` package (see ADR-0003).

--- a/docs/adr/0003-caddyfile-provider-dispatch-via-caddy-module-registry.md
+++ b/docs/adr/0003-caddyfile-provider-dispatch-via-caddy-module-registry.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+---
+
+# Caddyfile provider dispatch via Caddy's module registry
+
+Caddyfile `provider <type> <field> { }` blocks are dispatched through Caddy's
+own module registry: each provider contributes a Caddy module in the
+`xtemplate.providers.*` namespace (in an opt-in `providers/<type>/caddyfile`
+subpackage) implementing `CaddyfileProvider` (`ParseCaddyfile(h)
+(json.RawMessage, error)`). The `xtemplate/caddy` dispatch looks the module up
+by type, calls it, injects the reserved `"type"` and `"name"` keys, and appends
+the result to `ProvidersRaw`. This is a pure Caddyfile→JSON adapter and never
+touches the dot-provider registry (ADR-0001) or the provider packages, which
+stay Caddy-free.
+
+## Considered options
+
+- **Interface assertion on the config type** — look the provider up in the
+  dot-provider registry and assert its `DotConfig` has a `ParseBlock` method.
+  Rejected: that method would live in the provider package, forcing every
+  provider to import Caddy — re-creating the exact coupling ADR-0002 removed.
+- **Core-owned `BlockParser` abstraction** — hide `httpcaddyfile.Helper` behind
+  an `xtemplate`-owned interface. Rejected: leaks a Caddyfile-shaped concept
+  into a package that never reads a Caddyfile, and loses `h.ArgErr()` /
+  `h.Errf()` / nested-block support for provider authors.
+- **A custom Caddy-side registry** — a separate guarded map with
+  `RegisterCaddyfileProvider`. Rejected in favor of reusing Caddy's module
+  registry, which `xtemplate.funcs.*` already establishes as the repo's dispatch
+  pattern.
+
+## Consequences
+
+- `providers/<type>` stays Caddy-free; only the opt-in
+  `providers/<type>/caddyfile` package imports both Caddy and its provider.
+- `xtemplate/caddy/standard` blank-imports the default set's `caddyfile`
+  subpackages (and thereby their constructors), giving Caddy builds a one-`--with`
+  opt-in for `{sql, fs, flags, nats}`.
+- The `"type"` and `"name"` keys are reserved for the dispatch to inject; a
+  `ParseCaddyfile` implementation whose returned JSON contains either key is
+  rejected with a parse-time error, rather than being silently overwritten.
+- Caddyfile syntax is a curated subset of each provider's JSON surface; JSON is
+  the full-fidelity escape hatch, and options with no JSON representation (e.g.
+  nats jetstream `func`-typed options) remain Go-API-only.

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,9 +27,9 @@ the listed URL.
 | [`contacts`](./contacts/) | File-based routing + custom method routes + `.DB` (sqlite CRUD) | `mise run example-contacts` | 9001 | <http://localhost:9001/> |
 | [`sse-chat`](./sse-chat/) | Server-Sent Events with `.Flush` (live updates) | `mise run example-sse-chat` | 9002 | <http://localhost:9002/> |
 | [`blog`](./blog/) | Optimal asset serving: content-hash cache-busting + Subresource Integrity (`.X.StaticFileHash`) | `mise run example-blog` | 9003 | <http://localhost:9003/> |
-| [`filebrowser`](./filebrowser/) | Filesystem context provider (`.FS.ReadDir` / read files) | `mise run example-filebrowser` | 9004 | <http://localhost:9004/> |
+| [`filebrowser`](./filebrowser/) | Filesystem dot provider (`.FS.ReadDir` / read files) | `mise run example-filebrowser` | 9004 | <http://localhost:9004/> |
 | [`embedded`](./embedded/) | Single-binary deployment with `//go:embed` (custom build) | `mise run example-embedded` | 9005 | <http://localhost:9005/> |
-| [`dotprovider`](./dotprovider/) | Custom `DotProvider` exposing Go code to templates (custom build) | `mise run example-dotprovider` | 9006 | <http://localhost:9006/> |
+| [`dotprovider`](./dotprovider/) | Custom dot provider exposing Go code to templates (custom build) | `mise run example-dotprovider` | 9006 | <http://localhost:9006/> |
 
 ## How these are wired
 

--- a/examples/contacts/README.md
+++ b/examples/contacts/README.md
@@ -2,7 +2,7 @@
 
 A minimal CRUD app: file-based routing (`index.html` → `GET /`), custom method
 routes (`POST /contacts`, `POST /contacts/{id}/delete`), and the `.DB` sqlite
-context provider. Plain HTML forms with full-page reloads.
+dot provider. Plain HTML forms with full-page reloads.
 
 ```sh
 mise run example-contacts

--- a/examples/dotprovider/README.md
+++ b/examples/dotprovider/README.md
@@ -1,6 +1,6 @@
 # dotprovider example
 
-A custom `DotProvider` (the repository pattern): a small Go type exposes
+A custom dot provider (the repository pattern): a small Go type exposes
 hardcoded in-memory data to templates as `{{.Shop}}`. `templates/index.html`
 ranges over `{{.Shop.Products}}` and looks one up with `{{.Shop.Product 2}}`.
 
@@ -12,7 +12,7 @@ mise run example-dotprovider
 
 Then open http://localhost:9006/.
 
-## Writing a DotProvider
+## Writing a dot provider
 
 Implement `xtemplate.DotConfig` (`FieldName() string`, `Init(context.Context) error`,
 `Value(xtemplate.Request) (any, error)`), then register the instance via

--- a/examples/dotprovider/main.go
+++ b/examples/dotprovider/main.go
@@ -1,8 +1,8 @@
-// Custom DotProvider example: the "repository pattern". A custom provider
+// Custom dot provider example: the "repository pattern". A custom provider
 // exposes hardcoded in-memory data to templates as {{.Shop}}, which can range
 // over products and look one up by id.
 //
-// To write a DotProvider: implement xtemplate.DotConfig (FieldName, Init,
+// To write a dot provider: implement xtemplate.DotConfig (FieldName, Init,
 // Value), then register the instance with xtemplate.WithProvider passed to
 // app.Main. FieldName is the dot field name; Value returns the value assigned
 // to that field for each request.

--- a/examples/filebrowser/README.md
+++ b/examples/filebrowser/README.md
@@ -1,6 +1,6 @@
 # filebrowser example
 
-Lists a directory and shows file contents using the `.FS` context provider
+Lists a directory and shows file contents using the `.FS` dot provider
 (`.FS.ReadDir`, `.FS.Read`, `.FS.Exists`).
 
 ```sh

--- a/examples/filebrowser/files/readme.txt
+++ b/examples/filebrowser/files/readme.txt
@@ -1,3 +1,3 @@
 Welcome to the xtemplate filebrowser example.
 
-This directory is served read-only through the .FS context provider.
+This directory is served read-only through the .FS dot provider.

--- a/examples/hub/templates/index.html
+++ b/examples/hub/templates/index.html
@@ -22,9 +22,9 @@
       (list "Contacts" "File routing, custom method routes, and DB CRUD (sqlite).")
       (list "SSE chat" "Live updates streamed with Server-Sent Events and .Flush.")
       (list "Blog" "Content-hashed asset URLs and Subresource Integrity.")
-      (list "File browser" "Listing and reading files via the FS context provider.")
+      (list "File browser" "Listing and reading files via the FS dot provider.")
       (list "Embedded" "Single-binary deployment with //go:embed.")
-      (list "Custom DotProvider" "Exposing Go code to templates (the repository pattern).")
+      (list "Custom dot provider" "Exposing Go code to templates (the repository pattern).")
   }}
   <ul class="cards" id="cards">
     {{- range $i, $example := $examples }}

--- a/instance.go
+++ b/instance.go
@@ -207,11 +207,11 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 				}
 				err = tmpl.Execute(buf, *val)
 				if err = cleanup(val, err); err != nil {
-					return nil, nil, nil, fmt.Errorf("template initializer '%s' failed: %w", tmpl.Name(), err)
+					return nil, nil, nil, fmt.Errorf("initialization template '%s' failed: %w", tmpl.Name(), err)
 				}
 				// TODO: output buffer somewhere?
-				build.config.Logger.Debug("executed initializer", slog.String("template_name", tmpl.Name()), slog.Int("rendered_len", buf.Len()))
-				build.TemplateInitializers += 1
+				build.config.Logger.Debug("executed initialization template", slog.String("template_name", tmpl.Name()), slog.Int("rendered_len", buf.Len()))
+				build.InitializationTemplates += 1
 			}
 		}
 	}
@@ -222,7 +222,7 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 			slog.Int("routes", build.Routes),
 			slog.Int("templateFiles", build.TemplateFiles),
 			slog.Int("templateDefinitions", build.TemplateDefinitions),
-			slog.Int("templateInitializers", build.TemplateInitializers),
+			slog.Int("initializationTemplates", build.InitializationTemplates),
 			slog.Int("staticFiles", build.StaticFiles),
 			slog.Int("staticFilesAlternateEncodings", build.StaticFilesAlternateEncodings),
 		))

--- a/readme_test.go
+++ b/readme_test.go
@@ -187,7 +187,7 @@ func TestREADME_CustomRoute_DeleteContact(t *testing.T) {
 	}
 }
 
-// README "Database context provider": range over .DB.QueryRows results.
+// README "SQL dot provider": range over .DB.QueryRows results.
 func TestREADME_DBQueryRange(t *testing.T) {
 	db := newContactsDB(t)
 	inst := buildInstance(t,
@@ -207,7 +207,7 @@ func TestREADME_DBQueryRange(t *testing.T) {
 	}
 }
 
-// README "Filesystem context provider": list files with .FS.ReadDir and read
+// README "Filesystem dot provider": list files with .FS.ReadDir and read
 // each entry's name via the fs.FileInfo .Name method.
 func TestREADME_FSList(t *testing.T) {
 	dataFS := newMemFS(t, map[string]string{


### PR DESCRIPTION
This adds a glossary of xtemplate-specific terminology and updates docs and code to align with it. Also adds architecture decision records for the recent provider registry change.

I tried to make terms in the glossary clear and orthogonal. View: https://github.com/infogulch/xtemplate/blob/a95cc6cb8f270776173dca32283e32dd80f7031e/CONTEXT.md

I hope this will prevent terminology drift and help communication.