### PR TITLE
Add smtp core dot provider for synchronous mail sending

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -108,12 +108,30 @@ provider nats Nats {
 
 JetStream options and advanced `server.Options` fields have no JSON representation and must be set via the Go API.
 
+**smtp**: send mail synchronously over SMTP (send-only; body rendering stays in templates):
+
+```Caddy
+provider smtp Email {
+    host     smtp.example.com
+    from     noreply@example.com
+    username {env.SMTP_USER}
+    password {env.SMTP_PASS}
+    # port 587                  # default
+    # auth plain                # plain | login | cram-md5 | none (auto when empty)
+    # tls starttls              # starttls | tls | none
+    # helo mail.example.com
+    # max_recipients 50
+    # max_message_bytes 1048576
+    # send_timeout 30s
+}
+```
+
 #### Linking providers into the binary
 
-Provider Caddyfile support lives in opt-in subpackages. Use `caddy/standard` to pull in the default set (sql, fs, flags, nats) in one flag, or add one `--with` flag per provider to build a leaner subset.
+Provider Caddyfile support lives in opt-in subpackages. Use `caddy/standard` to pull in the default set (sql, fs, flags, nats, smtp) in one flag, or add one `--with` flag per provider to build a leaner subset.
 
 ```shell
-# default set (sql + fs + flags + nats Caddyfile + pure-Go sqlite3 driver)
+# default set (sql + fs + flags + nats + smtp Caddyfile + pure-Go sqlite3 driver)
 xcaddy build --with github.com/infogulch/xtemplate/caddy/standard
 
 # leaner subset: pick desired providers (and a SQL driver) individually

--- a/caddy/standard/standard.go
+++ b/caddy/standard/standard.go
@@ -1,5 +1,5 @@
 // Package standard links the default set of dot-provider Caddyfile parsers
-// (sql, fs, flags, nats), the pure-Go sqlite3 database/sql driver, and the
+// (sql, fs, flags, nats, smtp), the pure-Go sqlite3 database/sql driver, and the
 // xtemplate caddy module in a single opt-in import.
 //
 // Usage:
@@ -16,6 +16,7 @@ import (
 	_ "github.com/infogulch/xtemplate/providers/dotflags/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotfs/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotnats/caddyfile"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotsql/caddyfile"
 
 	_ "github.com/ncruces/go-sqlite3/driver"

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp"
 	_ "github.com/infogulch/xtemplate/providers/dotsql"
 
 	_ "github.com/ncruces/go-sqlite3/driver"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp"
 	_ "github.com/infogulch/xtemplate/providers/dotsql"
 
 	_ "github.com/ncruces/go-sqlite3/driver"

--- a/cmd/watchfs/main.go
+++ b/cmd/watchfs/main.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp"
 	_ "github.com/infogulch/xtemplate/providers/dotsql"
 
 	_ "github.com/ncruces/go-sqlite3/driver"

--- a/docs/how-to/custom-build.md
+++ b/docs/how-to/custom-build.md
@@ -13,7 +13,7 @@ xtemplate's packaging is intentionally like Caddy's: a thin `main` that blank-im
 | Git CLI | `./cmd/git` | Poll a Git remote; shallow-clone + reload on new commit |
 | Docker image | `infogulch/xtemplate` | Builds `./cmd` (plain) with listen default `:80` |
 | Caddy module (lean) | `caddy` | Core handler + Caddyfile surface; add `providers/*/caddyfile` as needed |
-| Caddy module (standard) | `caddy/standard` | Lean + Caddyfile parsers for sql, fs, flags, nats + pure-Go sqlite3 driver |
+| Caddy module (standard) | `caddy/standard` | Lean + Caddyfile parsers for sql, fs, flags, nats, smtp + pure-Go sqlite3 driver |
 
 Which variant to pick (including Caddy standard vs lean builds): [Deployment modes](../reference/deployment-modes.md).
 
@@ -40,6 +40,7 @@ import (
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp"
 	_ "github.com/infogulch/xtemplate/providers/dotsql"
 
 	_ "github.com/ncruces/go-sqlite3/driver"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -87,6 +87,14 @@ Providers are a list of objects with a `type` discriminator and a `name` (dot fi
           "dont_listen": true
         }
       }
+    },
+    {
+      "type": "smtp",
+      "name": "Email",
+      "host": "smtp.example.com",
+      "from": "noreply@example.com",
+      "username": "smtp-user",
+      "password": "smtp-pass"
     }
   ],
   "crossorigin": {
@@ -105,8 +113,11 @@ Providers are a list of objects with a `type` discriminator and a `name` (dot fi
 | `fs` | `providers/dotfs` | `name`, `path` |
 | `flags` | `providers/dotflags` | `name`, `values` (string map) |
 | `nats` | `providers/dotnats` | `name`, `nats_config`, … |
+| `smtp` | `providers/dotsmtp` | `name`, `host`, `from`, `port`, `username`, `password`, `auth`, `tls`, `helo`, `max_recipients`, `max_message_bytes`, `send_timeout` |
 
-Unknown `type` values error at load with a hint to import the registering package. The standard CLI blank-imports all four core providers.
+Unknown `type` values error at load with a hint to import the registering package. The standard CLI blank-imports all five core providers.
+
+For `smtp`, `send_timeout` is a Go `time.Duration`: in JSON it is a **nanosecond integer** (for example `30000000000` for 30s). Caddyfile `send_timeout 30s` is converted for you.
 
 Multiple providers of the same type are allowed if their `name` fields differ. For example, two SQL databases as separate dot fields:
 

--- a/docs/reference/deployment-modes.md
+++ b/docs/reference/deployment-modes.md
@@ -165,7 +165,7 @@ The `xtemplate/caddy` plugin integrates xtemplate into [Caddy](https://caddyserv
 
 | Build | xcaddy / download | Includes |
 |---|---|---|
-| standard | `--with github.com/infogulch/xtemplate/caddy/standard` | Handler + Caddyfile for sql/fs/flags/nats + pure-Go sqlite3 driver |
+| standard | `--with github.com/infogulch/xtemplate/caddy/standard` | Handler + Caddyfile for sql/fs/flags/nats/smtp + pure-Go sqlite3 driver |
 | lean | `--with …/caddy` plus selected `providers/dot*/caddyfile` | Only the providers you list |
 
 Download a prebuilt Caddy with the standard set:

--- a/docs/reference/dot-context.md
+++ b/docs/reference/dot-context.md
@@ -113,6 +113,19 @@ Package: [`providers/dotnats`](https://pkg.go.dev/github.com/infogulch/xtemplate
 
 For raw JSON provider config, nats connection options follow the [`nats.Options`](https://pkg.go.dev/github.com/nats-io/nats.go#Options) field names (e.g. `"Url"` with a capital `U` when setting the server URL). Caddyfile `conn_options { url … }` maps correctly via the Caddyfile adapter.
 
+### Email with `smtp`
+
+Package: [`providers/dotsmtp`](https://pkg.go.dev/github.com/infogulch/xtemplate/providers/dotsmtp). Provider type: `"smtp"`. Synchronous, send-only SMTP delivery. Body rendering stays with [`.X.Template`](#instance-data-in-x); this provider only transports already-rendered strings. There is no built-in queue — compose with `nats`/JetStream if you need durable async delivery.
+
+Typical field name: `.Email`. Config requires `host` and `from` (default sender). Optional connection settings: `port` (default 587), `username` / `password`, `auth` (`plain`, `login`, `cram-md5`, `none`, or empty for auto), `tls` (`starttls` default, `tls`, `none`), `helo`. Safety limits: `max_recipients` (default 50), `max_message_bytes` (default 1 MiB), `send_timeout` (default 30s; JSON is nanoseconds — see [Configuration](configuration.md#provider-types)).
+
+```html
+{{$body := .X.Template "email/welcome.html" .}}
+{{$id := .Email.Send "alice@example.com" "Welcome!" $body}}
+```
+
+`Send(to, subject, body, extra…)` delivers one message and returns the generated Message-ID. `to` is a single address string or a list of address strings (each string is one RFC 5322 address; recipients are not split on commas). Optional final map keys: `cc`, `bcc` (same shape as `to`), `from` (override default sender), `replyTo`, `text` (plaintext alternative). Unknown keys and wrong value types error.
+
 ## Custom providers
 
 Implement `xtemplate.DotConfig` and attach with `WithProvider` (or register a provider type for JSON/Caddyfile). See [How to create a custom dot provider](../how-to/create-a-provider.md) and [`examples/dotprovider`](../../examples/dotprovider/).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -48,7 +48,7 @@ Domain terms for xtemplate. Behavior and APIs live in the rest of the [docs](../
 
 **Builtin provider**: Supplied by xtemplate: `.X` and `.Req` always; `.Resp` on buffered handlers; `.Flush` on flushing handlers.
 
-**Core provider**: Package under `xtemplate/providers` (`sql`, `fs`, `flags`, `nats`).
+**Core provider**: Package under `xtemplate/providers` (`sql`, `fs`, `flags`, `nats`, `smtp`).
 
 **Standard provider set**: Types included in release binaries (`cmd/*`). For Caddy, blank-import `xtemplate/caddy/standard`.
 

--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,13 @@ require (
 	github.com/infogulch/watch v0.2.0
 	github.com/klauspost/compress v1.18.6
 	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/mocktools/go-smtp-mock/v2 v2.5.4
 	github.com/nats-io/nats-server/v2 v2.14.2
 	github.com/nats-io/nats.go v1.52.0
 	github.com/ncruces/go-sqlite3 v0.35.0
 	github.com/spf13/afero v1.15.0
 	github.com/tdewolff/minify/v2 v2.24.13
+	github.com/wneessen/go-mail v0.8.0
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
 	go.abhg.dev/goldmark/frontmatter v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mocktools/go-smtp-mock/v2 v2.5.4 h1:U89Y4SuOhDFUfboMYUtXzWDp7hNLrofRa5yNqGSESSM=
+github.com/mocktools/go-smtp-mock/v2 v2.5.4/go.mod h1:qBGjYXy5jKKVFhDnB39DYQfn4hWfcqWAlJTcvrku3rg=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nats-io/jwt/v2 v2.8.2 h1:XXRgB60MSTnqsRwejQurVDs/hcv2dkt+86GjI+I/bMc=
@@ -367,6 +369,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -392,6 +395,8 @@ github.com/tdewolff/test v1.0.12/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
+github.com/wneessen/go-mail v0.8.0 h1:I65TZ7+oYA+Kcme8GeJrBzfVioKDezj8f/BS+XhVpEE=
+github.com/wneessen/go-mail v0.8.0/go.mod h1:EkVXlu2G11/WYwPBElvN7QQ2c7IKIk0Nexs8BIPVsoQ=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/providers.go
+++ b/providers.go
@@ -38,7 +38,7 @@ func resolveProviders(raw []json.RawMessage) ([]DotConfig, error) {
 		ctor, ok := registry[probe.Type]
 		if !ok {
 			switch probe.Type {
-			case "sql", "fs", "flags", "nats":
+			case "sql", "fs", "flags", "nats", "smtp":
 				return nil, fmt.Errorf("xtemplate: unknown provider type %q; add it by importing github.com/infogulch/xtemplate/providers/dot%s", probe.Type, probe.Type)
 			default:
 				return nil, fmt.Errorf("xtemplate: unknown provider type %q; ensure the provider package that registers type %q is imported", probe.Type, probe.Type)

--- a/providers/dotsmtp/caddyfile/caddyfile.go
+++ b/providers/dotsmtp/caddyfile/caddyfile.go
@@ -1,0 +1,127 @@
+// Package caddyfile registers the smtp dot-provider for Caddyfile use.
+// Blank-import this package to enable `provider smtp <field> { }` blocks.
+//
+// Covered: host, port, username, password, auth, tls, from, max_recipients,
+// max_message_bytes, send_timeout. Only the curated JSON subset of
+// DotSMTPConfig is mirrored here — no import of go-mail is needed.
+package caddyfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	xtc "github.com/infogulch/xtemplate/caddy"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp"
+)
+
+type smtpCaddyfile struct{}
+
+func init() { caddy.RegisterModule(smtpCaddyfile{}) }
+
+func (smtpCaddyfile) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "xtemplate.providers.smtp",
+		New: func() caddy.Module { return new(smtpCaddyfile) },
+	}
+}
+
+var _ xtc.CaddyfileProvider = (*smtpCaddyfile)(nil)
+
+func (smtpCaddyfile) ParseCaddyfile(h httpcaddyfile.Helper) (json.RawMessage, error) {
+	// Local struct mirrors only the curated JSON subset of DotSMTPConfig.
+	// SendTimeout is emitted as a nanosecond integer because time.Duration
+	// (the target field's type) unmarshals from a JSON number.
+	type result struct {
+		Host            string `json:"host,omitempty"`
+		Port            int    `json:"port,omitempty"`
+		Username        string `json:"username,omitempty"`
+		Password        string `json:"password,omitempty"`
+		Auth            string `json:"auth,omitempty"`
+		TLS             string `json:"tls,omitempty"`
+		Helo            string `json:"helo,omitempty"`
+		From            string `json:"from,omitempty"`
+		MaxRecipients   int    `json:"max_recipients,omitempty"`
+		MaxMessageBytes int64  `json:"max_message_bytes,omitempty"`
+		SendTimeout     int64  `json:"send_timeout,omitempty"`
+	}
+
+	cfg := &result{}
+	for h.NextBlock(1) {
+		key := h.Val()
+		switch key {
+		case "host", "username", "password", "auth", "tls", "helo", "from":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			switch key {
+			case "host":
+				cfg.Host = s
+			case "username":
+				cfg.Username = s
+			case "password":
+				cfg.Password = s
+			case "auth":
+				cfg.Auth = s
+			case "tls":
+				cfg.TLS = s
+			case "helo":
+				cfg.Helo = s
+			case "from":
+				cfg.From = s
+			}
+		case "port", "max_recipients":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				return nil, h.Errf("%s must be an integer: %v", key, err)
+			}
+			if key == "port" {
+				cfg.Port = n
+			} else {
+				cfg.MaxRecipients = n
+			}
+		case "max_message_bytes":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return nil, h.Errf("max_message_bytes must be an integer: %v", err)
+			}
+			cfg.MaxMessageBytes = n
+		case "send_timeout":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return nil, h.Errf("send_timeout must be a duration (e.g. 30s): %v", err)
+			}
+			cfg.SendTimeout = d.Nanoseconds()
+		default:
+			return nil, h.Errf("unknown smtp provider option '%s'", key)
+		}
+	}
+
+	if cfg.Host == "" {
+		return nil, h.Errf("smtp provider requires a 'host' key")
+	}
+	if cfg.From == "" {
+		return nil, h.Errf("smtp provider requires a 'from' key")
+	}
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("smtp: marshal config: %w", err)
+	}
+	return out, nil
+}

--- a/providers/dotsmtp/caddyfile/caddyfile_test.go
+++ b/providers/dotsmtp/caddyfile/caddyfile_test.go
@@ -1,0 +1,158 @@
+package caddyfile_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	caddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+
+	xtc "github.com/infogulch/xtemplate/caddy"
+	_ "github.com/infogulch/xtemplate/providers/dotsmtp/caddyfile"
+)
+
+func parse(t *testing.T, body string) (json.RawMessage, error) {
+	t.Helper()
+	input := "outer {\n\tprovider smtp Email {\n" + body + "\n\t}\n}"
+	h := httpcaddyfile.Helper{}.WithDispenser(caddyfile.NewTestDispenser(input))
+	h.Next()       // "outer"
+	h.NextBlock(0) // → "provider"
+	h.NextArg()    // "smtp"
+	h.NextArg()    // "Email"
+	mi, err := caddy.GetModule("xtemplate.providers.smtp")
+	if err != nil {
+		t.Fatalf("GetModule: %v", err)
+	}
+	return mi.New().(xtc.CaddyfileProvider).ParseCaddyfile(h)
+}
+
+func TestSMTPCaddyfile_Full(t *testing.T) {
+	raw, err := parse(t, "\t\thost smtp.example.com\n\t\tport 465\n\t\tusername me\n\t\tpassword secret\n\t\tauth plain\n\t\ttls tls\n\t\tfrom noreply@example.com\n\t\tmax_recipients 25\n\t\tmax_message_bytes 2097152\n\t\tsend_timeout 45s")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var got struct {
+		Host            string `json:"host"`
+		Port            int    `json:"port"`
+		Username        string `json:"username"`
+		Password        string `json:"password"`
+		Auth            string `json:"auth"`
+		TLS             string `json:"tls"`
+		From            string `json:"from"`
+		MaxRecipients   int    `json:"max_recipients"`
+		MaxMessageBytes int64  `json:"max_message_bytes"`
+		SendTimeout     int64  `json:"send_timeout"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Host != "smtp.example.com" {
+		t.Errorf("host = %q", got.Host)
+	}
+	if got.Port != 465 {
+		t.Errorf("port = %d, want 465", got.Port)
+	}
+	if got.Username != "me" {
+		t.Errorf("username = %q", got.Username)
+	}
+	if got.Password != "secret" {
+		t.Errorf("password = %q", got.Password)
+	}
+	if got.Auth != "plain" {
+		t.Errorf("auth = %q", got.Auth)
+	}
+	if got.TLS != "tls" {
+		t.Errorf("tls = %q", got.TLS)
+	}
+	if got.From != "noreply@example.com" {
+		t.Errorf("from = %q", got.From)
+	}
+	if got.MaxRecipients != 25 {
+		t.Errorf("max_recipients = %d, want 25", got.MaxRecipients)
+	}
+	if got.MaxMessageBytes != 2097152 {
+		t.Errorf("max_message_bytes = %d, want 2097152", got.MaxMessageBytes)
+	}
+	if got.SendTimeout != int64(45*time.Second.Nanoseconds()) {
+		t.Errorf("send_timeout = %d, want %d", got.SendTimeout, int64(45*time.Second.Nanoseconds()))
+	}
+}
+
+func TestSMTPCaddyfile_SendTimeoutDuration(t *testing.T) {
+	raw, err := parse(t, "\t\thost smtp.example.com\n\t\tfrom noreply@example.com\n\t\tsend_timeout 1m30s")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var got struct {
+		SendTimeout int64 `json:"send_timeout"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if want := int64((90 * time.Second).Nanoseconds()); got.SendTimeout != want {
+		t.Errorf("send_timeout = %d, want %d", got.SendTimeout, want)
+	}
+}
+
+func TestSMTPCaddyfile_EmptyBlock(t *testing.T) {
+	if _, err := parse(t, ""); err == nil {
+		t.Fatal("expected error for empty block (host/from required), got nil")
+	}
+}
+
+func TestSMTPCaddyfile_MissingFrom(t *testing.T) {
+	if _, err := parse(t, "\t\thost smtp.example.com"); err == nil {
+		t.Fatal("expected error for missing from, got nil")
+	}
+}
+
+func TestSMTPCaddyfile_MissingHost(t *testing.T) {
+	if _, err := parse(t, "\t\tfrom noreply@example.com"); err == nil {
+		t.Fatal("expected error for missing host, got nil")
+	}
+}
+
+func TestSMTPCaddyfile_NoTypeOrNameKeys(t *testing.T) {
+	// The dispatch injects "type" and "name"; the parser must not emit them.
+	raw, err := parse(t, "\t\thost smtp.example.com\n\t\tfrom noreply@example.com")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["type"]; ok {
+		t.Error("parser emitted reserved 'type' key")
+	}
+	if _, ok := m["name"]; ok {
+		t.Error("parser emitted reserved 'name' key")
+	}
+}
+
+func TestSMTPCaddyfile_Errors(t *testing.T) {
+	cases := map[string]string{
+		"unknown key":          "\t\tbogus val",
+		"non-int port":         "\t\thost h\n\t\tfrom f@x.com\n\t\tport notanint",
+		"non-int max_rec":      "\t\thost h\n\t\tfrom f@x.com\n\t\tmax_recipients x",
+		"non-int max_bytes":    "\t\thost h\n\t\tfrom f@x.com\n\t\tmax_message_bytes x",
+		"bad duration":         "\t\thost h\n\t\tfrom f@x.com\n\t\tsend_timeout notaduration",
+		"missing arg for host": "",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if name == "missing arg for host" {
+				// A bare key with no arg is an arg error.
+				if _, err := parse(t, "\t\thost"); err == nil {
+					t.Errorf("expected error for %q", name)
+				}
+				return
+			}
+			if _, err := parse(t, body); err == nil {
+				t.Errorf("expected error for %q", name)
+			}
+		})
+	}
+}

--- a/providers/dotsmtp/smtp.go
+++ b/providers/dotsmtp/smtp.go
@@ -1,0 +1,424 @@
+// Package smtp implements the smtp core dot provider, which exposes
+// synchronous send-only SMTP mail delivery to templates via a dot field.
+//
+// Body rendering stays with the existing .X.Template; this provider only
+// transports rendered strings. Sending is synchronous and bounded by
+// send_timeout; there is no built-in queue. Applications that want durable
+// async delivery should compose this with dotnats/JetStream.
+package dotsmtp
+
+import (
+	"context"
+	"fmt"
+	"net/mail"
+	"time"
+
+	"github.com/infogulch/xtemplate"
+	gomail "github.com/wneessen/go-mail"
+)
+
+func init() {
+	xtemplate.Register("smtp", func() xtemplate.DotConfig { return &DotSMTPConfig{} })
+}
+
+// WithSMTP creates an [xtemplate.Option] that adds an smtp dot provider to the
+// config. It is a thin convenience over [xtemplate.WithProvider] for Go-API
+// users; Caddyfile/JSON users configure the provider via its struct fields.
+func WithSMTP(cfg *DotSMTPConfig) xtemplate.Option {
+	return func(c *xtemplate.Config) error {
+		c.Providers = append(c.Providers, cfg)
+		return nil
+	}
+}
+
+// DotSMTPConfig configures an xtemplate dot field that provides SMTP mail
+// sending to templates.
+type DotSMTPConfig struct {
+	// Name is the dot field name the provider contributes (required).
+	Name string `json:"name"`
+	// Host is the SMTP server hostname (required).
+	Host string `json:"host"`
+	// From is the default RFC 5322 sender address (required; may be overridden
+	// per-send via the "from" extra option).
+	From string `json:"from"`
+
+	// Port defaults to 587.
+	Port int `json:"port"`
+	// Username for SMTP auth. When non-empty and Auth is empty, auth defaults
+	// to "plain".
+	Username string `json:"username"`
+	// Password for SMTP auth.
+	Password string `json:"password"`
+	// Auth selects the SASL mechanism: "plain", "login", "cram-md5", "none",
+	// or "" (auto: plain if Username set, else none).
+	Auth string `json:"auth"`
+	// TLS selects the transport policy: "starttls" (default), "tls" (implicit
+	// TLS), or "none".
+	TLS string `json:"tls"`
+	// Helo is the EHLO/HELO identity sent to the server. When empty, go-mail
+	// uses os.Hostname(); set explicitly when the hostname is unsuitable (e.g.
+	// inside containers).
+	Helo string `json:"helo"`
+
+	// MaxRecipients caps the total number of To+Cc+Bcc recipients per send
+	// (default 50).
+	MaxRecipients int `json:"max_recipients"`
+	// MaxMessageBytes caps len(html)+len(text) per send (default 1 MiB).
+	MaxMessageBytes int64 `json:"max_message_bytes"`
+	// SendTimeout bounds a single DialAndSend (default 30s).
+	SendTimeout time.Duration `json:"send_timeout"`
+
+	// client is built in Init and reused across sends; go-mail dials a fresh
+	// connection per DialAndSendWithContext, so the client itself is stateless
+	// between sends.
+	client *gomail.Client
+}
+
+var _ xtemplate.DotConfig = &DotSMTPConfig{}
+
+// FieldName returns the dot field name contributed by this provider.
+func (d *DotSMTPConfig) FieldName() string { return d.Name }
+
+// Init applies defaults, validates required fields, and builds the go-mail
+// client. It does not dial; go-mail dials per send.
+func (d *DotSMTPConfig) Init(ctx context.Context) error {
+	if d.Port < 0 {
+		return fmt.Errorf("smtp: port must be >= 0")
+	}
+	if d.MaxMessageBytes < 0 {
+		return fmt.Errorf("smtp: max_message_bytes must be >= 0")
+	}
+	if d.MaxRecipients < 0 {
+		return fmt.Errorf("smtp: max_recipients must be >= 0")
+	}
+	if d.SendTimeout < 0 {
+		return fmt.Errorf("smtp: send_timeout must be >= 0")
+	}
+	if d.Host == "" {
+		return fmt.Errorf("smtp: host is required")
+	}
+	if d.From == "" {
+		return fmt.Errorf("smtp: from is required")
+	}
+	if _, err := mail.ParseAddress(d.From); err != nil {
+		return fmt.Errorf("smtp: invalid default from address %q: %w", d.From, err)
+	}
+
+	// Apply defaults.
+	if d.Port == 0 {
+		d.Port = 587
+	}
+	if d.TLS == "" {
+		d.TLS = "starttls"
+	}
+	if d.MaxRecipients == 0 {
+		d.MaxRecipients = 50
+	}
+	if d.MaxMessageBytes == 0 {
+		d.MaxMessageBytes = 1 << 20
+	}
+	if d.SendTimeout == 0 {
+		d.SendTimeout = 30 * time.Second
+	}
+
+	opts := []gomail.Option{gomail.WithPort(d.Port)}
+
+	switch d.TLS {
+	case "tls":
+		// Implicit TLS (typically port 465).
+		opts = append(opts, gomail.WithTLSPolicy(gomail.TLSMandatory), gomail.WithSSL())
+	case "starttls":
+		// Explicit STARTTLS (typically port 587).
+		opts = append(opts, gomail.WithTLSPolicy(gomail.TLSMandatory))
+	case "none":
+		opts = append(opts, gomail.WithTLSPolicy(gomail.NoTLS))
+	default:
+		return fmt.Errorf("smtp: unknown tls policy %q (want tls, starttls, or none)", d.TLS)
+	}
+
+	authType := d.Auth
+	if authType == "" {
+		if d.Username != "" {
+			authType = "plain"
+		} else {
+			authType = "none"
+		}
+	}
+	switch authType {
+	case "plain":
+		opts = append(opts, gomail.WithSMTPAuth(gomail.SMTPAuthPlain))
+	case "login":
+		opts = append(opts, gomail.WithSMTPAuth(gomail.SMTPAuthLogin))
+	case "cram-md5":
+		opts = append(opts, gomail.WithSMTPAuth(gomail.SMTPAuthCramMD5))
+	case "none":
+		// no auth
+	default:
+		return fmt.Errorf("smtp: unknown auth type %q (want plain, login, cram-md5, or none)", d.Auth)
+	}
+
+	if d.Username != "" {
+		opts = append(opts, gomail.WithUsername(d.Username))
+	}
+	if d.Password != "" {
+		opts = append(opts, gomail.WithPassword(d.Password))
+	}
+	if d.Helo != "" {
+		opts = append(opts, gomail.WithHELO(d.Helo))
+	}
+	opts = append(opts, gomail.WithTimeout(d.SendTimeout))
+
+	client, err := gomail.NewClient(d.Host, opts...)
+	if err != nil {
+		return fmt.Errorf("smtp: build client: %w", err)
+	}
+	d.client = client
+	return nil
+}
+
+// Value returns the per-request dot value. The returned type carries the
+// request context so a cancelled request aborts the in-flight send.
+func (d *DotSMTPConfig) Value(r xtemplate.Request) (any, error) {
+	return &DotSMTP{cfg: d, ctx: r.R.Context()}, nil
+}
+
+// DotSMTP is the per-request dot value exposed to templates. Call Send to
+// deliver a message synchronously.
+type DotSMTP struct {
+	cfg *DotSMTPConfig
+	ctx context.Context
+}
+
+// Send delivers a single message synchronously and returns the generated
+// Message-ID.
+//
+//	to      any              – a single address string or a []string / []any of
+//	                          address strings. Each string is one RFC 5322
+//	                          address (display-name form allowed); recipients
+//	                          are not split on commas. Required.
+//	subject string           – the Subject header.
+//	body    string           – the HTML body.
+//	extra   ...map[string]any – zero or one options map. Supported keys:
+//	                          "cc", "bcc" (string or list, as per "to"),
+//	                          "from" (string override), "replyTo" (string),
+//	                          "text" (plaintext alternative). Unknown keys
+//	                          are rejected.
+func (d *DotSMTP) Send(to any, subject, body string, extra ...map[string]any) (string, error) {
+	if len(extra) > 1 {
+		return "", fmt.Errorf("smtp: Send accepts at most one extra options map, got %d", len(extra))
+	}
+
+	msg := map[string]any{
+		"to":      to,
+		"subject": subject,
+		"html":    body,
+	}
+	if len(extra) == 1 {
+		for k, v := range extra[0] {
+			switch k {
+			case "cc", "bcc", "from", "replyTo", "text":
+				msg[k] = v
+			default:
+				return "", fmt.Errorf("smtp: unknown Send option %q", k)
+			}
+		}
+	}
+	return d.sendMap(msg)
+}
+
+// sendMap is the single source of truth for assembling and delivering a
+// message from the canonical schema. A future SendMap entry point will call
+// this directly.
+//
+//	Canonical schema:
+//	  "to"      any        string or []string (normalised)
+//	  "subject" string
+//	  "html"    string
+//	  "text"    string     (optional)
+//	  "cc"      []string   (optional)
+//	  "bcc"     []string   (optional)
+//	  "from"    string     (optional; defaults to cfg.From)
+//	  "replyTo" string     (optional)
+func (d *DotSMTP) sendMap(m map[string]any) (string, error) {
+	to, err := normaliseRecipients(m["to"], true)
+	if err != nil {
+		return "", err
+	}
+	cc, err := normaliseRecipients(m["cc"], false)
+	if err != nil {
+		return "", err
+	}
+	bcc, err := normaliseRecipients(m["bcc"], false)
+	if err != nil {
+		return "", err
+	}
+
+	getField := func(key string) (string, error) {
+		if v, ok := m[key]; ok {
+			if s, ok := v.(string); ok {
+				return s, nil
+			} else {
+				return "", fmt.Errorf("smtp: %s field must be a string, got %T", key, v)
+			}
+		}
+		return "", nil
+	}
+
+	subject, err := getField("subject")
+	if err != nil {
+		return "", err
+	}
+	html, err := getField("html")
+	if err != nil {
+		return "", err
+	}
+	text, err := getField("text")
+	if err != nil {
+		return "", err
+	}
+
+	// Recipient limit.
+	if total := len(to) + len(cc) + len(bcc); total > d.cfg.MaxRecipients {
+		return "", fmt.Errorf("smtp: %d recipients exceeds max_recipients %d", total, d.cfg.MaxRecipients)
+	}
+	// Conservative body-size pre-check (the assembled MIME message is slightly
+	// larger due to headers/encoding).
+	if bodyBytes := int64(len(html) + len(text)); bodyBytes > d.cfg.MaxMessageBytes {
+		return "", fmt.Errorf("smtp: body of %d bytes exceeds max_message_bytes %d", bodyBytes, d.cfg.MaxMessageBytes)
+	}
+	if d.cfg.client == nil {
+		return "", fmt.Errorf("smtp: client not initialized; Init was not called or failed")
+	}
+
+	from, err := getField("from")
+	if err != nil {
+		return "", err
+	} else if from == "" {
+		from = d.cfg.From
+	} else if _, err := mail.ParseAddress(from); err != nil {
+		return "", fmt.Errorf("smtp: invalid from address %q: %w", from, err)
+	}
+
+	replyTo, err := getField("replyTo")
+	if err != nil {
+		return "", err
+	} else if replyTo != "" {
+		if _, err := mail.ParseAddress(replyTo); err != nil {
+			return "", fmt.Errorf("smtp: invalid reply-to address %q: %w", replyTo, err)
+		}
+	}
+
+	gm := gomail.NewMsg()
+	if err := gm.From(from); err != nil {
+		return "", fmt.Errorf("smtp: set from: %w", err)
+	}
+	if err := gm.To(to...); err != nil {
+		return "", fmt.Errorf("smtp: set to: %w", err)
+	}
+	if len(cc) > 0 {
+		if err := gm.Cc(cc...); err != nil {
+			return "", fmt.Errorf("smtp: set cc: %w", err)
+		}
+	}
+	if len(bcc) > 0 {
+		if err := gm.Bcc(bcc...); err != nil {
+			return "", fmt.Errorf("smtp: set bcc: %w", err)
+		}
+	}
+	if replyTo != "" {
+		if err := gm.ReplyTo(replyTo); err != nil {
+			return "", fmt.Errorf("smtp: set reply-to: %w", err)
+		}
+	}
+	gm.Subject(subject)
+
+	switch {
+	case html != "" && text != "":
+		gm.SetBodyString(gomail.TypeTextHTML, html)
+		gm.AddAlternativeString(gomail.TypeTextPlain, text)
+	case html != "":
+		gm.SetBodyString(gomail.TypeTextHTML, html)
+	case text != "":
+		gm.SetBodyString(gomail.TypeTextPlain, text)
+	default:
+		gm.SetBodyString(gomail.TypeTextPlain, "")
+	}
+
+	// Generate a Message-ID so callers can correlate the sent message.
+	gm.SetMessageID()
+
+	if err := d.cfg.client.DialAndSendWithContext(d.ctx, gm); err != nil {
+		return "", fmt.Errorf("smtp: send: %w", err)
+	}
+	return gm.GetMessageID(), nil
+}
+
+// normaliseRecipients parses a recipient field into a list of validated RFC
+// 5322 address strings. One input string is exactly one address — no
+// comma-splitting. When required is false, an empty/nil field is allowed and
+// yields nil (the caller omits the header).
+func normaliseRecipients(v any, required bool) ([]string, error) {
+	switch val := v.(type) {
+	case nil:
+		if required {
+			return nil, fmt.Errorf("smtp: recipient is required")
+		}
+		return nil, nil
+	case string:
+		if val == "" {
+			if required {
+				return nil, fmt.Errorf("smtp: recipient is required")
+			}
+			return nil, nil
+		}
+		addr, err := mail.ParseAddress(val)
+		if err != nil {
+			return nil, fmt.Errorf("smtp: invalid address %q: %w", val, err)
+		}
+		return []string{addr.String()}, nil
+	case []string:
+		if len(val) == 0 {
+			if required {
+				return nil, fmt.Errorf("smtp: recipient is required")
+			}
+			return nil, nil
+		}
+		out := make([]string, 0, len(val))
+		for _, s := range val {
+			if s == "" {
+				return nil, fmt.Errorf("smtp: empty address in recipient list")
+			}
+			addr, err := mail.ParseAddress(s)
+			if err != nil {
+				return nil, fmt.Errorf("smtp: invalid address %q: %w", s, err)
+			}
+			out = append(out, addr.String())
+		}
+		return out, nil
+	case []any:
+		if len(val) == 0 {
+			if required {
+				return nil, fmt.Errorf("smtp: recipient is required")
+			}
+			return nil, nil
+		}
+		out := make([]string, 0, len(val))
+		for _, e := range val {
+			s, ok := e.(string)
+			if !ok {
+				return nil, fmt.Errorf("smtp: recipient list element must be string, got %T", e)
+			}
+			if s == "" {
+				return nil, fmt.Errorf("smtp: empty address in recipient list")
+			}
+			addr, err := mail.ParseAddress(s)
+			if err != nil {
+				return nil, fmt.Errorf("smtp: invalid address %q: %w", s, err)
+			}
+			out = append(out, addr.String())
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("smtp: recipient must be a string or list of strings, got %T", v)
+	}
+}

--- a/providers/dotsmtp/smtp_test.go
+++ b/providers/dotsmtp/smtp_test.go
@@ -1,0 +1,313 @@
+package dotsmtp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/infogulch/xtemplate"
+	smtpmock "github.com/mocktools/go-smtp-mock/v2"
+)
+
+// buildInstance mirrors the dotnats test helper: it builds an xtemplate
+// instance backed by an in-memory fs and the given provider options.
+func buildInstance(t *testing.T, files map[string]string, opts ...xtemplate.Option) *xtemplate.Instance {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	for name, content := range files {
+		if err := afero.WriteFile(fs, name, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write file %q to mem fs: %v", name, err)
+		}
+	}
+	cfg := xtemplate.New()
+	allOpts := append([]xtemplate.Option{xtemplate.WithTemplateFS(fs)}, opts...)
+	inst, _, _, err := cfg.Instance(allOpts...)
+	if err != nil {
+		t.Fatalf("failed to build instance: %v", err)
+	}
+	return inst
+}
+
+func doRequest(inst *xtemplate.Instance, method, target string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(method, target, nil)
+	inst.ServeHTTP(w, r)
+	return w
+}
+
+// newMockSMTP starts an in-process go-smtp-mock server on a dynamic port and
+// tears it down when the test finishes. MultipleMessageReceiving is enabled so
+// go-mail's post-delivery RSET preserves the completed message instead of
+// flushing it.
+func newMockSMTP(t *testing.T) *smtpmock.Server {
+	t.Helper()
+	srv := smtpmock.New(smtpmock.ConfigurationAttr{
+		HostAddress:              "127.0.0.1",
+		PortNumber:               0, // OS-assigned
+		MultipleMessageReceiving: true,
+	})
+	if err := srv.Start(); err != nil {
+		t.Fatalf("failed to start mock smtp server: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Stop() })
+	return srv
+}
+
+// --- Init: defaults & validation (no network) ---
+
+func TestInit_Defaults(t *testing.T) {
+	cfg := &DotSMTPConfig{
+		Name: "Email",
+		Host: "smtp.example.com",
+		From: "noreply@example.com",
+	}
+	if err := cfg.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// Defaults are applied on the same struct so they're observable.
+	if cfg.Port != 587 {
+		t.Errorf("Port = %d, want 587", cfg.Port)
+	}
+	if cfg.TLS != "starttls" {
+		t.Errorf("TLS = %q, want starttls", cfg.TLS)
+	}
+	if cfg.MaxRecipients != 50 {
+		t.Errorf("MaxRecipients = %d, want 50", cfg.MaxRecipients)
+	}
+	if cfg.MaxMessageBytes != 1<<20 {
+		t.Errorf("MaxMessageBytes = %d, want %d", cfg.MaxMessageBytes, 1<<20)
+	}
+	if cfg.SendTimeout != 30*time.Second {
+		t.Errorf("SendTimeout = %v, want 30s", cfg.SendTimeout)
+	}
+}
+
+func TestInit_Validation(t *testing.T) {
+	cases := map[string]DotSMTPConfig{
+		"missing host": {Name: "Email", From: "noreply@example.com"},
+		"missing from": {Name: "Email", Host: "smtp.example.com"},
+		"malformed from": {
+			Name: "Email", Host: "smtp.example.com", From: "not an address",
+		},
+		"unknown tls": {
+			Name: "Email", Host: "smtp.example.com", From: "noreply@example.com", TLS: "garbage",
+		},
+		"unknown auth": {
+			Name: "Email", Host: "smtp.example.com", From: "noreply@example.com", Auth: "garbage",
+		},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := cfg.Init(context.Background()); err == nil {
+				t.Errorf("expected error for %q, got nil", name)
+			}
+		})
+	}
+}
+
+// --- recipient normalisation (no network) ---
+
+func TestNormaliseRecipients(t *testing.T) {
+	// Exercise via Send with a config whose client is nil would panic, so we
+	// instead drive normalisation through the public Send path on a config
+	// whose Init built a client against an unstarted mock — but that requires
+	// a server. Instead, assert the error shapes that normalisation produces
+	// by calling Send on a DotSMTP with a nil client: normalisation runs
+	// before the dial, so its errors surface without a server.
+	d := &DotSMTP{cfg: &DotSMTPConfig{
+		Host: "x", From: "noreply@example.com",
+		MaxRecipients: 50, MaxMessageBytes: 1 << 20,
+	}}
+
+	cases := []struct {
+		name    string
+		to      any
+		wantErr string
+	}{
+		{"nil required", nil, "recipient is required"},
+		{"empty string required", "", "recipient is required"},
+		{"empty list required", []string{}, "recipient is required"},
+		{"empty element", []string{"", "a@x.com"}, "empty address in recipient list"},
+		{"non-string element", []any{1}, "must be string"},
+		{"wrong type", 42, "must be a string or list of strings"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := d.Send(c.to, "s", "<p>b</p>")
+			if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("err = %v, want containing %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// --- extra-map parsing (no network) ---
+
+func TestExtraMapParsing(t *testing.T) {
+	d := &DotSMTP{cfg: &DotSMTPConfig{
+		Host: "x", From: "noreply@example.com",
+		MaxRecipients: 50, MaxMessageBytes: 1 << 20,
+	}}
+
+	t.Run("two maps error", func(t *testing.T) {
+		_, err := d.Send("a@x.com", "s", "b",
+			map[string]any{"text": "t"}, map[string]any{"text": "t2"})
+		if err == nil || !strings.Contains(err.Error(), "at most one extra options map") {
+			t.Errorf("err = %v, want at-most-one error", err)
+		}
+	})
+	t.Run("unknown key error", func(t *testing.T) {
+		_, err := d.Send("a@x.com", "s", "b", map[string]any{"bogus": 1})
+		if err == nil || !strings.Contains(err.Error(), "unknown Send option") {
+			t.Errorf("err = %v, want unknown-option error", err)
+		}
+	})
+	t.Run("zero maps ok (passes validation)", func(t *testing.T) {
+		_, err := d.Send("a@x.com", "s", "b")
+		// Extra parsing and normalisation both passed; the not-initialised
+		// guard fires because no Init ran. Assert that guard, not a validation
+		// error.
+		if err == nil {
+			t.Fatal("expected not-initialised error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Errorf("err = %v, want not-initialized", err)
+		}
+	})
+}
+
+// --- limit enforcement (no network) ---
+
+func TestLimitEnforcement(t *testing.T) {
+	d := &DotSMTP{cfg: &DotSMTPConfig{
+		Host: "x", From: "noreply@example.com",
+		MaxRecipients: 2, MaxMessageBytes: 10,
+	}}
+
+	t.Run("over max_recipients", func(t *testing.T) {
+		_, err := d.Send([]string{"a@x.com", "b@x.com", "c@x.com"}, "s", "b")
+		if err == nil || !strings.Contains(err.Error(), "exceeds max_recipients") {
+			t.Errorf("err = %v, want exceeds max_recipients", err)
+		}
+	})
+	t.Run("at limit ok (passes validation)", func(t *testing.T) {
+		_, err := d.Send([]string{"a@x.com", "b@x.com"}, "s", "b")
+		if err == nil {
+			t.Fatal("expected not-initialised error, got nil")
+		}
+		if strings.Contains(err.Error(), "max_recipients") {
+			t.Errorf("should not hit recipient limit, got %v", err)
+		}
+	})
+	t.Run("over max_message_bytes", func(t *testing.T) {
+		_, err := d.Send("a@x.com", "s", "this body is way too long for the limit")
+		if err == nil || !strings.Contains(err.Error(), "exceeds max_message_bytes") {
+			t.Errorf("err = %v, want exceeds max_message_bytes", err)
+		}
+	})
+}
+
+// --- recipient shape coverage (no network) ---
+
+func TestRecipientShapes(t *testing.T) {
+	d := &DotSMTP{cfg: &DotSMTPConfig{
+		Host: "x", From: "noreply@example.com",
+		MaxRecipients: 50, MaxMessageBytes: 1 << 20,
+	}}
+
+	shapes := []struct {
+		name string
+		to   any
+	}{
+		{"single string", "alice@example.com"},
+		{"display-name string", "Alice <alice@example.com>"},
+		{"[]string", []string{"a@x.com", "b@x.com"}},
+		{"[]any", []any{"a@x.com", "b@x.com"}},
+	}
+	for _, c := range shapes {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := d.Send(c.to, "s", "<p>b</p>")
+			// All of these should pass normalisation and limits, then hit the
+			// not-initialised guard (no Init ran). Anything mentioning
+			// recipient/address is a normalisation regression.
+			if err == nil {
+				t.Fatal("expected not-initialised error, got nil")
+			}
+			if strings.Contains(err.Error(), "recipient") || strings.Contains(err.Error(), "address") {
+				t.Errorf("normalisation rejected %q: %v", c.name, err)
+			}
+		})
+	}
+}
+
+// --- Integration: in-process mock SMTP server ---
+
+func TestDotSMTP_Send_Integration(t *testing.T) {
+	srv := newMockSMTP(t)
+
+	cfg := &DotSMTPConfig{
+		Name: "Email",
+		Host: "127.0.0.1",
+		Port: srv.PortNumber(),
+		From: "noreply@example.com",
+		TLS:  "none",
+		Helo: "localhost",
+	}
+	if err := cfg.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	inst := buildInstance(t,
+		map[string]string{
+			"send.html": `{{ $id := .Email.Send "test@example.com" "Hello" "<p>World</p>" }}{{ $id }}`,
+		},
+		xtemplate.WithProvider(cfg),
+	)
+
+	w := doRequest(inst, http.MethodGet, "/send")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	msgs, err := srv.WaitForMessagesAndPurge(1, 2*time.Second)
+	if err != nil {
+		t.Fatalf("waiting for mock message: %v", err)
+	}
+	// RSET after delivery creates a fresh (empty) message; find the completed
+	// one among the recorded sessions.
+	var m smtpmock.Message
+	for _, cand := range msgs {
+		if cand.IsConsistent() {
+			m = cand
+			break
+		}
+	}
+	if m.MailfromRequest() == "" {
+		t.Fatalf("no consistent message among %d recorded; first=%+v", len(msgs), msgs[0])
+	}
+	if got := m.MailfromRequest(); !strings.Contains(got, "noreply@example.com") {
+		t.Errorf("MAIL FROM = %q, want to contain noreply@example.com", got)
+	}
+	rr := m.RcpttoRequestResponse()
+	if len(rr) == 0 || !strings.Contains(rr[0][0], "test@example.com") {
+		t.Errorf("RCPT TO = %v, want test@example.com", rr)
+	}
+	body := m.MsgRequest()
+	if !strings.Contains(body, "Subject: Hello") {
+		t.Errorf("body missing Subject: Hello\n%s", body)
+	}
+	if !strings.Contains(body, "World") {
+		t.Errorf("body missing rendered HTML content\n%s", body)
+	}
+	// The template prints the returned Message-ID; html/template escapes the
+	// wrapping angle brackets, so the body is &lt;local@host&gt;.
+	id := strings.TrimSpace(w.Body.String())
+	if !strings.HasPrefix(id, "&lt;") || !strings.HasSuffix(id, "&gt;") || !strings.Contains(id, "@") {
+		t.Errorf("returned message id = %q, want an html-escaped <local@host> Message-ID", id)
+	}
+}


### PR DESCRIPTION
Exposes .Email.Send on the dot context via go-mail. Send-only and synchronous, bounded by send_timeout; durable async delivery is left to composition with dotnats/JetStream.

- providers/dotsmtp: DotSMTPConfig, DotSMTP.Send, caddyfile parser
- tests: unit (defaults, validation, normalisation, limits, extra map)
  + integration against an in-process go-smtp-mock server
- go-mail v0.8.0, go-smtp-mock/v2 v2.5.4

Fixes #5