### PR TITLE
Add writable fs provider with ReceiveFiles multipart upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `fs` provider: optional `writable` flag (default false). When true, the
+  template field is `DotFsRW` with `ReceiveFiles` for streaming multipart
+  uploads onto the provider FS; when false, the field stays read-only
+  (`DotFs`) and the backing FS is wrapped with afero `ReadOnlyFs`.
+- `dotfs.WithFsWritable` for Go API opt-in; Caddyfile `writable true` in
+  `provider fs` blocks. Init probes writability when `writable` is true.
+
 ## [v0.10.0] - 2026-07-12
 
 Uniform provider registry and Caddyfile provider dispatch.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -110,7 +110,7 @@ Providers are a list of objects with a `type` discriminator and a `name` (dot fi
 | `type` | Package | Typical fields |
 |---|---|---|
 | `sql` | `providers/dotsql` | `name`, `driver`, `connstr`, `max_open_conns` |
-| `fs` | `providers/dotfs` | `name`, `path` |
+| `fs` | `providers/dotfs` | `name`, `path`, `writable` (bool, default false) |
 | `flags` | `providers/dotflags` | `name`, `values` (string map) |
 | `nats` | `providers/dotnats` | `name`, `nats_config`, … |
 | `smtp` | `providers/dotsmtp` | `name`, `host`, `from`, `port`, `username`, `password`, `auth`, `tls`, `helo`, `max_recipients`, `max_message_bytes`, `send_timeout` |
@@ -152,6 +152,7 @@ route {
 		}
 		provider fs FS {
 			path data
+			# writable true   # enables ReceiveFiles; root must be writable
 		}
 		provider flags Flags {
 			env production

--- a/docs/reference/dot-context.md
+++ b/docs/reference/dot-context.md
@@ -101,7 +101,7 @@ Package: [`providers/dotfs`](https://pkg.go.dev/github.com/infogulch/xtemplate/p
 </ol>
 ```
 
-See [`examples/filebrowser`](../../examples/filebrowser/).
+Optional `writable: true` exposes multipart upload (`ReceiveFiles`). Full API: package docs. Demo: [`examples/filebrowser`](../../examples/filebrowser/).
 
 ### Static key/value config with `flags`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ the listed URL.
 | [`contacts`](./contacts/) | File-based routing + custom method routes + `.DB` (sqlite CRUD) | `mise run example-contacts` | 9001 | <http://localhost:9001/> |
 | [`sse-chat`](./sse-chat/) | Server-Sent Events with `.Flush` (live updates) | `mise run example-sse-chat` | 9002 | <http://localhost:9002/> |
 | [`blog`](./blog/) | Optimal asset serving: content-hash cache-busting + Subresource Integrity (`.X.StaticFileHash`) | `mise run example-blog` | 9003 | <http://localhost:9003/> |
-| [`filebrowser`](./filebrowser/) | Filesystem dot provider (`.FS.ReadDir` / read files) | `mise run example-filebrowser` | 9004 | <http://localhost:9004/> |
+| [`filebrowser`](./filebrowser/) | Filesystem dot provider (`.FS` list/read + `ReceiveFiles` upload) | `mise run example-filebrowser` | 9004 | <http://localhost:9004/> |
 | [`embedded`](./embedded/) | Single-binary deployment with `//go:embed` (custom build) | `mise run example-embedded` | 9005 | <http://localhost:9005/> |
 | [`dotprovider`](./dotprovider/) | Custom dot provider exposing Go code to templates (custom build) | `mise run example-dotprovider` | 9006 | <http://localhost:9006/> |
 

--- a/examples/filebrowser/README.md
+++ b/examples/filebrowser/README.md
@@ -1,10 +1,16 @@
 # filebrowser example
 
 Lists a directory and shows file contents using the `.FS` dot provider
-(`.FS.ReadDir`, `.FS.Read`, `.FS.Exists`).
+(`.FS.ReadDir`, `.FS.Read`, `.FS.Exists`). With `"writable": true`, each
+listing also offers multipart upload via `.FS.ReceiveFiles` (files land under
+`{dir}/{request-id}/` with sequential names and an `upload.json` manifest).
 
 ```sh
 mise run example-filebrowser
 ```
 
 Then open http://localhost:9004/
+
+```sh
+mise run test-example-filebrowser
+```

--- a/examples/filebrowser/config.json
+++ b/examples/filebrowser/config.json
@@ -4,7 +4,8 @@
     {
       "type": "fs",
       "name": "FS",
-      "path": "files"
+      "path": "files",
+      "writable": true
     }
   ]
 }

--- a/examples/filebrowser/files/readme.txt
+++ b/examples/filebrowser/files/readme.txt
@@ -1,3 +1,3 @@
 Welcome to the xtemplate filebrowser example.
 
-This directory is served read-only through the .FS dot provider.
+This directory is served through the .FS dot provider (writable for uploads).

--- a/examples/filebrowser/templates/{dir...}.html
+++ b/examples/filebrowser/templates/{dir...}.html
@@ -11,16 +11,27 @@
     {{.Resp.SetHeader "Location" (print "/" $dir "/")}}
     {{.Resp.ReturnStatus 307}}
 {{end}}
-<h1>Files in {{$dir}}</h1>
-{{if ne $dir "/"}}<p><a href="javascript:history.back()">&larr; back</a></p>{{end}}
+<h1>Files in {{or $dir "/"}}</h1>
+{{if ne $dir ""}}<p><a href="javascript:history.back()">&larr; back</a></p>{{end}}
 <ul>
     {{range .FS.ReadDir $dir}}
     <li>
         {{if .IsDir}}
-        <a href="/{{.Name}}/">[dir] {{.Name}}/</a>
+        <a href="/{{$dir}}{{.Name}}/">[dir] {{.Name}}/</a>
         {{else}}
         <a href="/view/{{$dir}}{{.Name}}">{{.Name}}</a> ({{.Size}} bytes)
         {{end}}
     </li>
     {{end}}
 </ul>
+<form method="POST" action="/upload{{with $dir}}?dir={{urlquery .}}{{end}}" enctype="multipart/form-data">
+    <label>Upload <input type="file" name="file" required></label>
+    <button type="submit">Upload</button>
+</form>
+
+{{define "POST /upload"}}
+{{$dest := or (.Req.URL.Query.Get "dir") "."}}
+{{$u := .FS.ReceiveFiles $dest 10 10485760}}
+{{.Resp.AddHeader "Location" (print "/" $u.Dir "/")}}
+{{.Resp.ReturnStatus 303}}
+{{end}}

--- a/examples/filebrowser/tests/filebrowser.hurl
+++ b/examples/filebrowser/tests/filebrowser.hurl
@@ -5,6 +5,7 @@ HTTP 200
 [Asserts]
 body contains "readme.txt"
 body contains "notes.md"
+body contains "multipart/form-data"
 
 # viewing a file's contents
 GET http://localhost:8080/view/readme.txt
@@ -34,3 +35,46 @@ HTTP 307
 GET http://localhost:8080/view/docs/hello.txt
 
 HTTP 200
+
+# multipart upload into the FS root (writable fs → ReceiveFiles)
+POST http://localhost:8080/upload
+[Multipart]
+file: file,upload-sample.txt; text/plain
+
+HTTP 303
+[Captures]
+upload_loc: header "Location"
+[Asserts]
+header "Location" matches "^/[^/]+/$"
+
+# listing the per-request upload dir shows the stored file
+GET http://localhost:8080{{upload_loc}}
+
+HTTP 200
+[Asserts]
+body contains "00.txt"
+body contains "upload.json"
+
+# view the stored upload contents
+GET http://localhost:8080/view{{upload_loc}}00.txt
+
+HTTP 200
+[Asserts]
+body contains "hello from filebrowser upload test"
+
+# upload into a subdirectory via ?dir=
+POST http://localhost:8080/upload?dir=docs/
+[Multipart]
+file: file,upload-sample.txt; text/plain
+
+HTTP 303
+[Captures]
+docs_upload_loc: header "Location"
+[Asserts]
+header "Location" matches "^/docs/[^/]+/$"
+
+GET http://localhost:8080{{docs_upload_loc}}
+
+HTTP 200
+[Asserts]
+body contains "00.txt"

--- a/examples/filebrowser/tests/upload-sample.txt
+++ b/examples/filebrowser/tests/upload-sample.txt
@@ -1,0 +1,1 @@
+hello from filebrowser upload test

--- a/providers/dotfs/caddyfile/caddyfile.go
+++ b/providers/dotfs/caddyfile/caddyfile.go
@@ -4,6 +4,7 @@ package caddyfile
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -26,17 +27,29 @@ var _ xtc.CaddyfileProvider = (*fsCaddyfile)(nil)
 
 func (fsCaddyfile) ParseCaddyfile(h httpcaddyfile.Helper) (json.RawMessage, error) {
 	var path string
+	var writable bool
 	for h.NextBlock(1) {
 		switch h.Val() {
 		case "path":
 			if !h.AllArgs(&path) {
 				return nil, h.ArgErr()
 			}
+		case "writable":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			b, err := strconv.ParseBool(s)
+			if err != nil {
+				return nil, h.Errf("writable must be a boolean: %v", err)
+			}
+			writable = b
 		default:
 			return nil, h.Errf("unknown fs provider option '%s'", h.Val())
 		}
 	}
 	return json.Marshal(struct {
-		Path string `json:"path"`
-	}{path})
+		Path     string `json:"path"`
+		Writable bool   `json:"writable,omitempty"`
+	}{path, writable})
 }

--- a/providers/dotfs/caddyfile/caddyfile_test.go
+++ b/providers/dotfs/caddyfile/caddyfile_test.go
@@ -33,13 +33,37 @@ func TestFsCaddyfile_HappyPath(t *testing.T) {
 		t.Fatalf("ParseCaddyfile: %v", err)
 	}
 	var got struct {
-		Path string `json:"path"`
+		Path     string `json:"path"`
+		Writable bool   `json:"writable"`
 	}
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Path != "/srv/data" {
 		t.Errorf("path = %q, want /srv/data", got.Path)
+	}
+	if got.Writable {
+		t.Errorf("writable = true, want false default")
+	}
+}
+
+func TestFsCaddyfile_Writable(t *testing.T) {
+	raw, err := parse(t, "\t\tpath /srv/data\n\t\twritable true")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var got struct {
+		Path     string `json:"path"`
+		Writable bool   `json:"writable"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Path != "/srv/data" {
+		t.Errorf("path = %q, want /srv/data", got.Path)
+	}
+	if !got.Writable {
+		t.Errorf("writable = false, want true")
 	}
 }
 
@@ -61,8 +85,10 @@ func TestFsCaddyfile_EmptyBlock(t *testing.T) {
 
 func TestFsCaddyfile_Errors(t *testing.T) {
 	cases := map[string]string{
-		"unknown key":      "\t\tbogus val",
-		"missing path arg": "\t\tpath",
+		"unknown key":          "\t\tbogus val",
+		"missing path arg":     "\t\tpath",
+		"bad writable":         "\t\twritable maybe",
+		"missing writable arg": "\t\twritable",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/providers/dotfs/fs.go
+++ b/providers/dotfs/fs.go
@@ -1,3 +1,58 @@
+// Package dotfs is the core filesystem [xtemplate] dot provider (type "fs").
+//
+// # Config
+//
+// JSON / provider config fields:
+//
+//   - name (required): dot field name, e.g. "FS" → {{.FS}}
+//   - path: root directory on disk when FS is not injected in Go
+//   - writable (bool, default false): when true, the per-request value is
+//     [DotFsRW] (read methods plus [DotFsRW.ReceiveFiles]); when false, [DotFs]
+//     only and the store is wrapped with [afero.NewReadOnlyFs]
+//
+// Go: [WithFs] (read-only) or [WithFsWritable]. Caddyfile: writable true inside
+// provider fs … { }.
+//
+// When writable is true, [DotFsConfig.Init] probes that the provider root can
+// create and delete a file; instance load fails otherwise. The root itself must
+// be writable (not only a subdirectory). Put auth in front of open upload routes.
+//
+// # Read API ([DotFs] / embedded in [DotFsRW])
+//
+// Read, ReadDir, Open, Stat, Exists, ExistsDir, Chroot.
+//
+// # Upload API ([DotFsRW.ReceiveFiles])
+//
+// Template signature: ReceiveFiles dir maxFiles maxBytes → [UploadResult]
+//
+// All three arguments are required. Streams multipart/form-data (MultipartReader,
+// not ParseMultipartForm) so large files are not fully buffered in memory.
+//
+//   - File parts (non-empty client filename) are stored under {dir}/{request-id}/
+//     with sequential basenames (00.jpg, 01.upload, …)—never the client path.
+//   - Non-file parts are seeded onto the request Form/PostForm/MultipartForm.Value
+//     so {{.Req.FormValue}} works after ReceiveFiles. Call ReceiveFiles before
+//     FormValue or ParseMultipartForm; a second call on the same request errors.
+//   - upload.json is written last with file metadata only (no text form fields;
+//     those may hold secrets). Original filenames appear in the manifest for
+//     debugging and may themselves be sensitive.
+//   - Stored extension: path.Ext of the original basename; body length 1–20 and
+//     charset [a-zA-Z0-9], lowercased; otherwise .upload.
+//   - dir must be a relative path without ".." under the provider root.
+//   - On failure after mkdir, the request directory is removed best-effort.
+//
+// Success and failure are logged at debug on the request logger.
+//
+// Example:
+//
+//	{{- define "POST /upload"}}
+//	{{$u := .FS.ReceiveFiles "uploads" 10 10485760}}
+//	{{$title := .Req.FormValue "title"}}
+//	{{.Resp.AddHeader "Location" (printf "/files/%s" $u.Dir)}}
+//	{{.Resp.ReturnStatus 303}}
+//	{{end}}
+//
+// Runnable demo (list, read, and upload): examples/filebrowser.
 package dotfs
 
 import (
@@ -8,8 +63,10 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net/http"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/infogulch/xtemplate"
 	"github.com/spf13/afero"
 )
@@ -22,23 +79,43 @@ func init() {
 
 // WithFs creates an [xtemplate.Option] that can be used with
 // [xtemplate.Config.Server], [xtemplate.Config.Instance], or [xtemplate.Main]
-// to add an fs dot provider to the config.
+// to add a read-only fs dot provider to the config.
+//
+// The given FS is wrapped with [afero.NewReadOnlyFs] during Init. To enable
+// uploads, use [WithFsWritable] or set [DotFsConfig.Writable].
 func WithFs(name string, afs afero.Fs) xtemplate.Option {
+	return withFs(name, afs, false)
+}
+
+// WithFsWritable is like [WithFs] but enables write/upload methods ([DotFsRW])
+// and runs an Init-time writability probe on the given FS.
+func WithFsWritable(name string, afs afero.Fs) xtemplate.Option {
+	return withFs(name, afs, true)
+}
+
+func withFs(name string, afs afero.Fs, writable bool) xtemplate.Option {
 	return func(c *xtemplate.Config) error {
 		if afs == nil {
 			return fmt.Errorf("cannot create DotFSProvider with null FS with name %s", name)
 		}
-		c.Providers = append(c.Providers, &DotFsConfig{Name: name, FS: afs})
+		c.Providers = append(c.Providers, &DotFsConfig{Name: name, FS: afs, Writable: writable})
 		return nil
 	}
 }
 
 // DotFsConfig configures an xtemplate dot field to provide file system access
 // to templates.
+//
+// When Writable is false (default), the template field is a [DotFs] with
+// read-only methods and the backing FS is wrapped with [afero.NewReadOnlyFs].
+// When Writable is true, the field is a [DotFsRW] that includes [DotFsRW.ReceiveFiles],
+// and Init probes that the root can create and delete files. The provider root
+// must be writable when Writable is true (not only a subdirectory).
 type DotFsConfig struct {
-	Name string   `json:"name"`
-	Path string   `json:"path"`
-	FS   afero.Fs `json:"-"`
+	Name     string   `json:"name"`
+	Path     string   `json:"path"`
+	Writable bool     `json:"writable"`
+	FS       afero.Fs `json:"-"`
 }
 
 var _ xtemplate.CleanupDotProvider = &DotFsConfig{}
@@ -46,43 +123,113 @@ var _ xtemplate.CleanupDotProvider = &DotFsConfig{}
 func (c *DotFsConfig) FieldName() string { return c.Name }
 
 func (p *DotFsConfig) Init(ctx context.Context) error {
-	if p.FS != nil {
+	if p.FS == nil {
+		newfs := afero.NewBasePathFs(afero.NewOsFs(), p.Path)
+		if _, err := newfs.Stat("."); err != nil {
+			return fmt.Errorf("failed to stat fs current directory '%s': %w", p.Path, err)
+		}
+		p.FS = newfs
+	}
+
+	if !p.Writable {
+		if _, ok := p.FS.(*afero.ReadOnlyFs); !ok {
+			p.FS = afero.NewReadOnlyFs(p.FS)
+		}
 		return nil
 	}
-	newfs := afero.NewBasePathFs(afero.NewOsFs(), p.Path)
-	if _, err := newfs.(interface {
-		Stat(string) (fs.FileInfo, error)
-	}).Stat("."); err != nil {
-		return fmt.Errorf("failed to stat fs current directory '%s': %w", p.Path, err)
+
+	return probeWritable(p.FS, p.rootHint())
+}
+
+func (p *DotFsConfig) rootHint() string {
+	if p.Path != "" {
+		return p.Path
 	}
-	p.FS = newfs
+	if p.Name != "" {
+		return p.Name
+	}
+	return "(injected FS)"
+}
+
+// probeWritable verifies the backing FS can create and delete a file under the
+// provider root. Called only from Init when writable is true.
+func probeWritable(afs afero.Fs, pathHint string) error {
+	if _, ok := afs.(*afero.ReadOnlyFs); ok {
+		return fmt.Errorf("fs provider root %q is wrapped with ReadOnlyFs; writable: true requires a writable filesystem", pathHint)
+	}
+
+	name := ".xtemplate-write-probe-" + uuid.NewString()
+	f, err := afs.Create(name)
+	if err != nil {
+		return fmt.Errorf("fs provider root %q is not writable (create probe failed): %w", pathHint, err)
+	}
+	// Best-effort remove on any exit path (including panic) so the probe file
+	// does not linger when possible.
+	removed := false
+	defer func() {
+		if !removed {
+			_ = afs.Remove(name)
+		}
+	}()
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("fs provider root %q is not writable (close probe failed): %w", pathHint, err)
+	}
+	if err := afs.Remove(name); err != nil {
+		return fmt.Errorf("fs provider root %q is not writable (remove probe failed): %w", pathHint, err)
+	}
+	removed = true
 	return nil
 }
 
 func (p *DotFsConfig) Value(r xtemplate.Request) (any, error) {
-	return DotFs{p.FS, xtemplate.GetLogger(r.R.Context()), make(map[afero.File]struct{})}, nil
+	base := DotFs{
+		fs:     p.FS,
+		log:    xtemplate.GetLogger(r.R.Context()),
+		opened: make(map[afero.File]struct{}),
+	}
+	if p.Writable {
+		received := false
+		return DotFsRW{
+			DotFs:    base,
+			w:        r.W,
+			r:        r.R,
+			received: &received,
+		}, nil
+	}
+	return base, nil
 }
 
 func (p *DotFsConfig) Cleanup(a any, err error) error {
-	v := a.(DotFs)
+	var d DotFs
+	switch v := a.(type) {
+	case DotFs:
+		d = v
+	case DotFsRW:
+		d = v.DotFs
+	default:
+		return err
+	}
+
 	errs := []error{}
-	for file := range v.opened {
-		if err := file.Close(); err != nil {
-			p := &fs.PathError{}
-			if errors.As(err, &p) && p.Op == "close" && p.Err.Error() == "file already closed" {
+	for file := range d.opened {
+		if cerr := file.Close(); cerr != nil {
+			pe := &fs.PathError{}
+			if errors.As(cerr, &pe) && pe.Op == "close" && pe.Err.Error() == "file already closed" {
 				// ignore
 			} else {
-				errs = append(errs, err)
+				errs = append(errs, cerr)
 			}
 		}
 	}
 	if len(errs) != 0 {
-		v.log.Warn("failed to close files", slog.Any("errors", errors.Join(errs...)))
+		d.log.Warn("failed to close files", slog.Any("errors", errors.Join(errs...)))
 	}
 	return err
 }
 
-// DotFs provides template access to a filesystem rooted at a configured path.
+// DotFs provides read-only template access to a filesystem rooted at a
+// configured path. Write/upload methods are not present; use [DotFsRW] via
+// writable: true.
 type DotFs struct {
 	fs  afero.Fs
 	log *slog.Logger
@@ -92,20 +239,47 @@ type DotFs struct {
 	opened map[afero.File]struct{}
 }
 
+// DotFsRW embeds [DotFs] for the shared read method set and adds request-scoped
+// state for [DotFsRW.ReceiveFiles]. Returned when the fs provider is configured
+// with writable: true.
+type DotFsRW struct {
+	DotFs
+	w http.ResponseWriter
+	r *http.Request
+	// received is a pointer so Chroot copies share the one-call-per-request flag.
+	received *bool
+}
+
 // Chroot returns a copy of the filesystem with root changed to path.
 func (d DotFs) Chroot(path string) (DotFs, error) {
 	if _, err := d.fs.Stat(path); err != nil {
 		return DotFs{}, fmt.Errorf("failed to chroot to %#v: %w", path, err)
 	}
-	afs := afero.NewBasePathFs(d.fs, path)
 	return DotFs{
-		fs:     afs,
+		fs:     afero.NewBasePathFs(d.fs, path),
 		log:    d.log,
 		opened: d.opened,
 	}, nil
 }
 
-// ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
+// Chroot returns a copy of the filesystem with root changed to path. The
+// result remains writable under the chroot and shares upload request state
+// with the parent.
+func (d DotFsRW) Chroot(path string) (DotFsRW, error) {
+	base, err := d.DotFs.Chroot(path)
+	if err != nil {
+		return DotFsRW{}, err
+	}
+	return DotFsRW{
+		DotFs:    base,
+		w:        d.w,
+		r:        d.r,
+		received: d.received,
+	}, nil
+}
+
+// ReadDir reads the directory named by dirname and returns a list of directory
+// entries sorted by filename.
 func (d DotFs) ReadDir(path string) ([]fs.FileInfo, error) {
 	return afero.ReadDir(d.fs, path)
 }

--- a/providers/dotfs/fs_test.go
+++ b/providers/dotfs/fs_test.go
@@ -1,8 +1,14 @@
 package dotfs_test
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -60,4 +66,347 @@ func TestDirProvider(t *testing.T) {
 	if body := w.Body.String(); !strings.Contains(body, "FILE-CONTENT") {
 		t.Errorf("body = %q, want it to contain %q", body, "FILE-CONTENT")
 	}
+}
+
+func TestInit_WritableProbeSucceedsAndNoLeftover(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	cfg := &dotfs.DotFsConfig{Name: "FS", FS: mem, Writable: true}
+	if err := cfg.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	entries, err := afero.ReadDir(mem, ".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".xtemplate-write-probe-") {
+			t.Errorf("probe file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestInit_WritableWithReadOnlyFsFails(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	ro := afero.NewReadOnlyFs(mem)
+	cfg := &dotfs.DotFsConfig{Name: "FS", FS: ro, Writable: true}
+	err := cfg.Init(context.Background())
+	if err == nil {
+		t.Fatal("Init: expected error for ReadOnlyFs with writable:true")
+	}
+	if !strings.Contains(err.Error(), "ReadOnlyFs") && !strings.Contains(err.Error(), "not writable") {
+		t.Errorf("Init error = %v, want mention of read-only/not writable", err)
+	}
+}
+
+func TestInit_NonWritableWrapsReadOnly(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	_ = afero.WriteFile(mem, "a.txt", []byte("x"), 0644)
+	cfg := &dotfs.DotFsConfig{Name: "FS", FS: mem, Writable: false}
+	if err := cfg.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, ok := cfg.FS.(*afero.ReadOnlyFs); !ok {
+		t.Fatalf("FS type = %T, want *afero.ReadOnlyFs", cfg.FS)
+	}
+	if err := afero.WriteFile(cfg.FS, "b.txt", []byte("y"), 0644); err == nil {
+		t.Fatal("expected write to fail on read-only wrapped FS")
+	}
+}
+
+func TestWritableFalse_ReceiveFilesUnknownField(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}{{.FS.ReceiveFiles "uploads" 10 1000}}{{end}}`,
+		},
+		dotfs.WithFs("FS", dataFS),
+	)
+
+	body, ctype := multipartBody(t, map[string]string{"title": "hi"}, nil)
+	w := postUpload(inst, body, ctype)
+	if w.Code == http.StatusOK {
+		t.Fatalf("status = %d, want error (ReceiveFiles not on read-only DotFs)", w.Code)
+	}
+}
+
+func TestReceiveFiles_HappyPath(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}
+{{- $u := .FS.ReceiveFiles "uploads" 10 10485760 -}}
+dir={{$u.Dir}}
+files={{len $u.Files}}
+title={{.Req.FormValue "title"}}
+stored={{(index $u.Files 0).StoredName}}
+orig={{(index $u.Files 0).OriginalName}}
+{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", dataFS),
+	)
+
+	body, ctype := multipartBody(t,
+		map[string]string{"title": "My Title"},
+		[]filePart{{field: "photo", name: "My Photo.JPG", data: []byte("jpeg-bytes")}},
+	)
+	w := postUpload(inst, body, ctype)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %q", w.Code, w.Body.String())
+	}
+	out := w.Body.String()
+	if !strings.Contains(out, "title=My Title") {
+		t.Errorf("body = %q, want FormValue title", out)
+	}
+	if !strings.Contains(out, "files=1") {
+		t.Errorf("body = %q, want files=1", out)
+	}
+	if !strings.Contains(out, "stored=00.jpg") {
+		t.Errorf("body = %q, want stored=00.jpg", out)
+	}
+	if !strings.Contains(out, "orig=My Photo.JPG") {
+		t.Errorf("body = %q, want original name", out)
+	}
+
+	rootEntries, err := afero.ReadDir(dataFS, "uploads")
+	if err != nil {
+		t.Fatalf("uploads dir: %v", err)
+	}
+	if len(rootEntries) != 1 {
+		t.Fatalf("want 1 request dir under uploads, got %d", len(rootEntries))
+	}
+	reqDir := path.Join("uploads", rootEntries[0].Name())
+	entries, err := afero.ReadDir(dataFS, reqDir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", reqDir, err)
+	}
+	foundUploadJSON := false
+	foundFile := false
+	for _, e := range entries {
+		switch {
+		case e.Name() == "upload.json":
+			foundUploadJSON = true
+			raw, err := afero.ReadFile(dataFS, path.Join(reqDir, "upload.json"))
+			if err != nil {
+				t.Fatalf("read upload.json: %v", err)
+			}
+			var m map[string]any
+			if err := json.Unmarshal(raw, &m); err != nil {
+				t.Fatalf("upload.json: %v", err)
+			}
+			if _, ok := m["fields"]; ok {
+				t.Error("upload.json must not contain fields key")
+			}
+			if m["version"].(float64) != 1 {
+				t.Errorf("version = %v, want 1", m["version"])
+			}
+			files, ok := m["files"].([]any)
+			if !ok || len(files) != 1 {
+				t.Fatalf("files = %v", m["files"])
+			}
+			f0 := files[0].(map[string]any)
+			if f0["original_name"] != "My Photo.JPG" {
+				t.Errorf("original_name = %v", f0["original_name"])
+			}
+			if f0["stored_name"] != "00.jpg" {
+				t.Errorf("stored_name = %v, want 00.jpg", f0["stored_name"])
+			}
+		case strings.HasSuffix(e.Name(), ".jpg"):
+			foundFile = true
+			data, _ := afero.ReadFile(dataFS, path.Join(reqDir, e.Name()))
+			if string(data) != "jpeg-bytes" {
+				t.Errorf("file content = %q", data)
+			}
+		}
+	}
+	if !foundUploadJSON {
+		t.Error("missing upload.json")
+	}
+	if !foundFile {
+		t.Error("missing stored image file")
+	}
+	if !strings.Contains(out, "dir="+reqDir) {
+		t.Errorf("body dir want %q in %q", reqDir, out)
+	}
+}
+
+func TestReceiveFiles_ExtensionPolicy(t *testing.T) {
+	cases := []struct {
+		name    string
+		orig    string
+		wantExt string
+	}{
+		{"normal", "photo.PNG", ".png"},
+		{"empty", "noext", ".upload"},
+		{"long", "x." + strings.Repeat("a", 21), ".upload"},
+		{"nonascii", "x.jpeǵ", ".upload"},
+		{"dots", "archive.tar.gz", ".gz"},
+		{"badchars", "x.foo-bar", ".upload"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataFS := newMemFS(t, nil)
+			inst := buildInstance(t,
+				map[string]string{
+					"routes.html": `{{define "POST /upload"}}{{$u := .FS.ReceiveFiles "up" 5 10000}}{{(index $u.Files 0).StoredName}}{{end}}`,
+				},
+				dotfs.WithFsWritable("FS", dataFS),
+			)
+			body, ctype := multipartBody(t, nil, []filePart{{field: "f", name: tc.orig, data: []byte("d")}})
+			w := postUpload(inst, body, ctype)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d body = %q", w.Code, w.Body.String())
+			}
+			got := strings.TrimSpace(w.Body.String())
+			if !strings.HasSuffix(got, tc.wantExt) {
+				t.Errorf("StoredName = %q, want suffix %q", got, tc.wantExt)
+			}
+		})
+	}
+}
+
+func TestReceiveFiles_TooManyFiles(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}{{.FS.ReceiveFiles "up" 1 10000}}{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", dataFS),
+	)
+	body, ctype := multipartBody(t, nil, []filePart{
+		{field: "a", name: "a.txt", data: []byte("1")},
+		{field: "b", name: "b.txt", data: []byte("2")},
+	})
+	w := postUpload(inst, body, ctype)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected error status, got 200 body=%q", w.Body.String())
+	}
+	if ents, _ := afero.ReadDir(dataFS, "up"); len(ents) != 0 {
+		t.Errorf("expected cleaned up dirs, got %v", ents)
+	}
+}
+
+func TestReceiveFiles_OversizeBody(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}{{.FS.ReceiveFiles "up" 10 32}}{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", dataFS),
+	)
+	big := bytes.Repeat([]byte("x"), 1000)
+	body, ctype := multipartBody(t, nil, []filePart{{field: "f", name: "big.bin", data: big}})
+	w := postUpload(inst, body, ctype)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected error for oversize, got 200")
+	}
+}
+
+func TestReceiveFiles_DoubleCall(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}
+{{$u := .FS.ReceiveFiles "up" 10 10000}}
+{{.FS.ReceiveFiles "up" 10 10000}}
+{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", dataFS),
+	)
+	body, ctype := multipartBody(t, map[string]string{"t": "1"}, []filePart{{field: "f", name: "a.txt", data: []byte("hi")}})
+	w := postUpload(inst, body, ctype)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected error on double ReceiveFiles, got 200 body=%q", w.Body.String())
+	}
+}
+
+func TestReceiveFiles_NonMultipart(t *testing.T) {
+	dataFS := newMemFS(t, nil)
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}{{.FS.ReceiveFiles "up" 10 10000}}{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", dataFS),
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader("x=y"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	inst.ServeHTTP(w, r)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected error for non-multipart, got 200")
+	}
+}
+
+func TestReceiveFiles_MidStreamFailureCleansUp(t *testing.T) {
+	base := afero.NewMemMapFs()
+	// failAfter 2: Init write probe uses Create once; the next Create is the
+	// stored upload file and should fail so the request dir is cleaned up.
+	ffs := &failAfterNCreates{Fs: base, failAfter: 2}
+
+	inst := buildInstance(t,
+		map[string]string{
+			"routes.html": `{{define "POST /upload"}}{{.FS.ReceiveFiles "up" 10 10000}}{{end}}`,
+		},
+		dotfs.WithFsWritable("FS", ffs),
+	)
+	body, ctype := multipartBody(t, nil, []filePart{{field: "f", name: "a.txt", data: []byte("hi")}})
+	w := postUpload(inst, body, ctype)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected failure, got 200")
+	}
+	if ents, err := afero.ReadDir(base, "up"); err == nil && len(ents) != 0 {
+		t.Errorf("expected cleanup of request dir, still have %v", ents)
+	}
+}
+
+func postUpload(inst *xtemplate.Instance, body *bytes.Buffer, ctype string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/upload", body)
+	r.Header.Set("Content-Type", ctype)
+	inst.ServeHTTP(w, r)
+	return w
+}
+
+type filePart struct {
+	field string
+	name  string
+	data  []byte
+}
+
+func multipartBody(t *testing.T, fields map[string]string, files []filePart) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range files {
+		pw, err := mw.CreateFormFile(f.field, f.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pw.Write(f.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+// failAfterNCreates wraps an afero.Fs and fails Create after N successful creates.
+type failAfterNCreates struct {
+	afero.Fs
+	failAfter int
+	creates   int
+}
+
+func (f *failAfterNCreates) Create(name string) (afero.File, error) {
+	f.creates++
+	if f.creates >= f.failAfter {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return f.Fs.Create(name)
 }

--- a/providers/dotfs/upload.go
+++ b/providers/dotfs/upload.go
@@ -1,0 +1,395 @@
+package dotfs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/infogulch/xtemplate"
+	"github.com/spf13/afero"
+)
+
+// UploadResult is returned by [DotFsRW.ReceiveFiles] for template use
+// (redirect, DB insert) without reading upload.json.
+type UploadResult struct {
+	Dir   string
+	Files []UploadedFile
+}
+
+// UploadedFile describes one stored file part from a multipart upload.
+type UploadedFile struct {
+	FormName     string
+	OriginalName string
+	StoredName   string
+	Size         int64
+	ContentType  string
+}
+
+// uploadManifest is written as upload.json under the request directory.
+// Non-file form fields are intentionally omitted (may contain secrets).
+type uploadManifest struct {
+	Version    int                  `json:"version"`
+	ReceivedAt string               `json:"received_at"`
+	RequestID  string               `json:"request_id"`
+	Dir        string               `json:"dir"`
+	Limits     uploadManifestLimits `json:"limits"`
+	TotalBytes int64                `json:"total_bytes"`
+	Files      []uploadManifestFile `json:"files"`
+}
+
+type uploadManifestLimits struct {
+	MaxFiles int   `json:"max_files"`
+	MaxBytes int64 `json:"max_bytes"`
+}
+
+type uploadManifestFile struct {
+	Index        int    `json:"index"`
+	FormName     string `json:"form_name"`
+	OriginalName string `json:"original_name"`
+	StoredName   string `json:"stored_name"`
+	Size         int64  `json:"size"`
+	ContentType  string `json:"content_type"`
+}
+
+// ReceiveFiles streams a multipart/form-data body into dir/<request-id>/,
+// stores file parts under sequential basenames, seeds non-file fields onto
+// the request for later .Req.FormValue use, and writes upload.json last.
+//
+// See the package doc for limits, layout, extension rules, call order, and
+// security notes. Template signature: ReceiveFiles dir maxFiles maxBytes → UploadResult.
+func (d DotFsRW) ReceiveFiles(dir string, maxFiles, maxBytes int) (UploadResult, error) {
+	var (
+		nFiles     int
+		totalBytes int64
+	)
+
+	ctx := context.Background()
+	if d.r != nil {
+		ctx = d.r.Context()
+	}
+
+	fail := func(err error) (UploadResult, error) {
+		attrs := []slog.Attr{
+			slog.String("dir", dir),
+			slog.Int("files", nFiles),
+			slog.Int64("total_bytes", totalBytes),
+			slog.Any("error", err),
+		}
+		var es xtemplate.ErrorStatus
+		if errors.As(err, &es) {
+			attrs = append(attrs, slog.Int("status", int(es)))
+		}
+		d.log.LogAttrs(ctx, slog.LevelDebug, "ReceiveFiles failed", attrs...)
+		return UploadResult{}, err
+	}
+
+	if d.r == nil {
+		return fail(fmt.Errorf("ReceiveFiles: no request available"))
+	}
+	r := d.r
+	w := d.w
+
+	if d.received == nil {
+		return fail(fmt.Errorf("ReceiveFiles: missing request state"))
+	}
+	if *d.received {
+		return fail(fmt.Errorf("ReceiveFiles: already called for this request"))
+	}
+	if r.MultipartForm != nil {
+		return fail(fmt.Errorf("ReceiveFiles: multipart form already parsed; call ReceiveFiles before FormValue/ParseMultipartForm"))
+	}
+
+	if maxFiles < 0 {
+		return fail(fmt.Errorf("ReceiveFiles: maxFiles must be >= 0"))
+	}
+	if maxBytes < 0 {
+		return fail(fmt.Errorf("ReceiveFiles: maxBytes must be >= 0"))
+	}
+
+	cleanDir, err := cleanUploadDir(dir)
+	if err != nil {
+		return fail(err)
+	}
+
+	rid := xtemplate.GetRequestId(r.Context())
+	if rid == "" {
+		return fail(fmt.Errorf("ReceiveFiles: failed to get request id: %w", err))
+	}
+
+	reqDir := path.Join(cleanDir, rid)
+	if _, err := d.fs.Stat(reqDir); err == nil {
+		return fail(fmt.Errorf("ReceiveFiles: request directory %q already exists", reqDir))
+	} else if !isNotExist(err) {
+		return fail(fmt.Errorf("ReceiveFiles: stat request dir: %w", err))
+	}
+
+	// Mark received early so a second call on the same request fails even if
+	// the first attempt errors after this point. Pointer so Chroot shares it.
+	*d.received = true
+
+	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
+	mr, err := r.MultipartReader()
+	if err != nil {
+		return fail(clientErr(fmt.Errorf("ReceiveFiles: not a multipart request: %w", err)))
+	}
+
+	if err := d.fs.MkdirAll(reqDir, 0o755); err != nil {
+		return fail(fmt.Errorf("ReceiveFiles: mkdir %q: %w", reqDir, err))
+	}
+
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		if remErr := d.fs.RemoveAll(reqDir); remErr != nil {
+			d.log.Warn("failed to clean up upload request dir",
+				slog.String("dir", reqDir),
+				slog.Any("error", remErr),
+			)
+		}
+	}()
+
+	ensureForm(r)
+
+	pad := len(strconv.Itoa(maxFiles))
+	if pad < 0 {
+		return fail(fmt.Errorf("ReceiveFiles: invalid maxFiles %d", maxFiles))
+	}
+
+	var files []UploadedFile
+	var manifestFiles []uploadManifestFile
+
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fail(mapBodyErr(fmt.Errorf("ReceiveFiles: read part: %w", err)))
+		}
+
+		filename := part.FileName()
+		formName := part.FormName()
+
+		// Empty client filename: treat as non-file field (do not store).
+		if filename == "" {
+			val, err := readPartString(part, int64(maxBytes))
+			_ = part.Close()
+			if err != nil {
+				return fail(mapBodyErr(fmt.Errorf("ReceiveFiles: read field %q: %w", formName, err)))
+			}
+			seedFormField(r, formName, val)
+			continue
+		}
+
+		if len(files) >= maxFiles {
+			_ = part.Close()
+			return fail(clientErr(fmt.Errorf("ReceiveFiles: too many files (max %d)", maxFiles)))
+		}
+
+		ext := storedExtension(filename)
+		idx := len(files)
+		storedName := fmt.Sprintf("%0*d%s", pad, idx, ext)
+		outPath := path.Join(reqDir, storedName)
+		ct := part.Header.Get("Content-Type")
+
+		out, err := d.fs.Create(outPath)
+		if err != nil {
+			_ = part.Close()
+			return fail(fmt.Errorf("ReceiveFiles: create %q: %w", outPath, err))
+		}
+		n, copyErr := io.Copy(out, part)
+		closeErr := out.Close()
+		_ = part.Close()
+		if copyErr != nil {
+			return fail(mapBodyErr(fmt.Errorf("ReceiveFiles: write %q: %w", outPath, copyErr)))
+		}
+		if closeErr != nil {
+			return fail(fmt.Errorf("ReceiveFiles: close %q: %w", outPath, closeErr))
+		}
+
+		uf := UploadedFile{
+			FormName:     formName,
+			OriginalName: filename,
+			StoredName:   storedName,
+			Size:         n,
+			ContentType:  ct,
+		}
+		files = append(files, uf)
+		manifestFiles = append(manifestFiles, uploadManifestFile{
+			Index:        idx,
+			FormName:     formName,
+			OriginalName: filename,
+			StoredName:   storedName,
+			Size:         n,
+			ContentType:  ct,
+		})
+		totalBytes += n
+		nFiles = len(files)
+	}
+
+	manifest := uploadManifest{
+		Version:    1,
+		ReceivedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		RequestID:  rid,
+		Dir:        reqDir,
+		Limits: uploadManifestLimits{
+			MaxFiles: maxFiles,
+			MaxBytes: int64(maxBytes),
+		},
+		TotalBytes: totalBytes,
+		Files:      manifestFiles,
+	}
+	if err := writeUploadJSON(d.fs, reqDir, manifest); err != nil {
+		return fail(err)
+	}
+
+	success = true
+	result := UploadResult{Dir: reqDir, Files: files}
+
+	d.log.LogAttrs(ctx, slog.LevelDebug, "ReceiveFiles ok",
+		slog.String("dir", reqDir),
+		slog.Int("files", nFiles),
+		slog.Int64("total_bytes", totalBytes),
+	)
+	return result, nil
+}
+
+func cleanUploadDir(dir string) (string, error) {
+	if dir == "" {
+		return "", clientErr(fmt.Errorf("ReceiveFiles: dir must not be empty"))
+	}
+	cleaned := path.Clean(dir)
+	if path.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", clientErr(fmt.Errorf("ReceiveFiles: dir must be a relative path without '..': %q", dir))
+	}
+	// Reject volume/drive paths and backslashes.
+	if len(cleaned) >= 2 && cleaned[1] == ':' {
+		return "", clientErr(fmt.Errorf("ReceiveFiles: dir must be a relative path: %q", dir))
+	}
+	if strings.Contains(dir, "\\") || strings.Contains(cleaned, "\\") {
+		return "", clientErr(fmt.Errorf("ReceiveFiles: dir must use '/' separators: %q", dir))
+	}
+	// path.Clean can leave "foo/.." as cleaned forms; after Clean, ".." segments
+	// should only remain as prefix we already rejected. Also reject absolute
+	// after Clean of paths like "/abs".
+	if strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") {
+		return "", clientErr(fmt.Errorf("ReceiveFiles: dir must be a relative path without '..': %q", dir))
+	}
+	return cleaned, nil
+}
+
+// storedExtension returns a leading-dot extension for storage, or ".upload".
+// Rules: path.Ext of the basename; body length 1–20; charset [a-zA-Z0-9];
+// lowercase when storing.
+func storedExtension(originalName string) string {
+	base := path.Base(strings.ReplaceAll(originalName, "\\", "/"))
+	ext := path.Ext(base)
+	if ext == "" || ext == "." {
+		return ".upload"
+	}
+	body := ext[1:]
+	if len(body) < 1 || len(body) > 20 {
+		return ".upload"
+	}
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return ".upload"
+		}
+	}
+	return "." + strings.ToLower(body)
+}
+
+func ensureForm(r *http.Request) {
+	if r.PostForm == nil {
+		r.PostForm = make(url.Values)
+	}
+	if r.Form == nil {
+		r.Form = make(url.Values)
+		for k, vs := range r.URL.Query() {
+			r.Form[k] = append([]string{}, vs...)
+		}
+	}
+	if r.MultipartForm == nil {
+		r.MultipartForm = &multipart.Form{
+			Value: make(map[string][]string),
+			File:  make(map[string][]*multipart.FileHeader),
+		}
+	} else {
+		if r.MultipartForm.Value == nil {
+			r.MultipartForm.Value = make(map[string][]string)
+		}
+		if r.MultipartForm.File == nil {
+			r.MultipartForm.File = make(map[string][]*multipart.FileHeader)
+		}
+	}
+}
+
+func seedFormField(r *http.Request, name, value string) {
+	r.PostForm.Add(name, value)
+	r.Form.Add(name, value)
+	r.MultipartForm.Value[name] = append(r.MultipartForm.Value[name], value)
+}
+
+func readPartString(part *multipart.Part, max int64) (string, error) {
+	var r io.Reader = part
+	if max >= 0 {
+		r = io.LimitReader(part, max+1)
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	if max >= 0 && int64(len(b)) > max {
+		return "", &http.MaxBytesError{Limit: max}
+	}
+	return string(b), nil
+}
+
+func writeUploadJSON(afs afero.Fs, reqDir string, manifest uploadManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("ReceiveFiles: marshal upload.json: %w", err)
+	}
+	tmp := path.Join(reqDir, "upload.json.tmp")
+	final := path.Join(reqDir, "upload.json")
+	if err := afero.WriteFile(afs, tmp, data, 0o644); err != nil {
+		return fmt.Errorf("ReceiveFiles: write upload.json.tmp: %w", err)
+	}
+	if err := afs.Rename(tmp, final); err != nil {
+		_ = afs.Remove(tmp)
+		if err2 := afero.WriteFile(afs, final, data, 0o644); err2 != nil {
+			return fmt.Errorf("ReceiveFiles: write upload.json: %w", err2)
+		}
+	}
+	return nil
+}
+
+func clientErr(err error) error {
+	return fmt.Errorf("%w: %w", xtemplate.ErrorStatus(http.StatusBadRequest), err)
+}
+
+func mapBodyErr(err error) error {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return clientErr(fmt.Errorf("body exceeds maxBytes limit: %w", err))
+	}
+	return err
+}
+
+func isNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, afero.ErrFileNotFound)
+}

--- a/providers/dotfs/upload_test.go
+++ b/providers/dotfs/upload_test.go
@@ -1,0 +1,43 @@
+package dotfs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStoredExtension(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"photo.JPG", ".jpg"},
+		{"a.b.C", ".c"},
+		{"noext", ".upload"},
+		{"ends.", ".upload"},
+		{"x." + strings.Repeat("a", 21), ".upload"},
+		{"x.jpeǵ", ".upload"},
+		{"x.foo-bar", ".upload"},
+		{`C:\path\file.PNG`, ".png"},
+		{"", ".upload"},
+	}
+	for _, tc := range cases {
+		if got := storedExtension(tc.in); got != tc.want {
+			t.Errorf("storedExtension(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCleanUploadDir(t *testing.T) {
+	ok, err := cleanUploadDir("uploads")
+	if err != nil || ok != "uploads" {
+		t.Fatalf("uploads: got %q, %v", ok, err)
+	}
+	ok, err = cleanUploadDir("a/b/../c")
+	if err != nil || ok != "a/c" {
+		t.Fatalf("a/b/../c: got %q, %v", ok, err)
+	}
+	for _, bad := range []string{"", "..", "../x", "/abs", `C:\x`, `foo\bar`} {
+		if _, err := cleanUploadDir(bad); err == nil {
+			t.Errorf("cleanUploadDir(%q): want error", bad)
+		}
+	}
+}


### PR DESCRIPTION
Closes #8: optional writable:true exposes DotFsRW.ReceiveFiles for streaming form uploads into per-request dirs, with read-only DotFs still the default.