### PR TITLE
Add in-process bus provider and multi-user sse-chat

### DIFF
--- a/.config/mise/tasks/test-example-sse-chat
+++ b/.config/mise/tasks/test-example-sse-chat
@@ -10,10 +10,10 @@ let server = (job spawn {
     ^$bin --loglevel -4 --config-file config.json --listen :0 out+err> server.log
 })
 let port = (wait-listen-port ($work | path join server.log))
-let outcome = (try {
-    run-lightpanda-sse $"http://localhost:($port)/?count=3&delay=10" --selector "#feed li" --contains "message 3"
-    "ok"
-} catch { |e| $e.msg })
+# Hurl covers page render, Publish, and the SSE Accept check. Bus→SSE fan-out
+# is covered by providers/dotbus tests (long-lived EventSource streams are a
+# poor fit for lightpanda's wait-selector).
+let outcome = (try { run-example $port $work; "ok" } catch { |e| $e.msg })
 job kill $server
 if $outcome != "ok" {
     print -e $"test-example-sse-chat failed: ($outcome)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `bus` provider (`providers/dotbus`): process-local multi-producer
+  multi-consumer topic fan-out for single-process SSE / live UI.
+  Template API: `Publish(topic, message)`, `Subscribe(topic)`. Optional
+  `buffer` (default 16); slow subscribers drop rather than block publishers.
+  Caddyfile: `provider bus <field> { buffer <n> }`. Included in standard CLI
+  and `caddy/standard` builds.
 - `fs` provider: optional `writable` flag (default false). When true, the
   template field is `DotFsRW` with `ReceiveFiles` for streaming multipart
   uploads onto the provider FS; when false, the field stays read-only

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -93,6 +93,14 @@ provider flags Flags {
 }
 ```
 
+**bus**: process-local topic fan-out (no broker; good for single-process SSE):
+
+```Caddy
+provider bus Bus {
+    # buffer 16   # per-subscriber channel capacity (default 16)
+}
+```
+
 **nats**: connect to a NATS messaging server:
 
 ```Caddy
@@ -128,10 +136,10 @@ provider smtp Email {
 
 #### Linking providers into the binary
 
-Provider Caddyfile support lives in opt-in subpackages. Use `caddy/standard` to pull in the default set (sql, fs, flags, nats, smtp) in one flag, or add one `--with` flag per provider to build a leaner subset.
+Provider Caddyfile support lives in opt-in subpackages. Use `caddy/standard` to pull in the default set (sql, fs, flags, bus, nats, smtp) in one flag, or add one `--with` flag per provider to build a leaner subset.
 
 ```shell
-# default set (sql + fs + flags + nats + smtp Caddyfile + pure-Go sqlite3 driver)
+# default set (sql + fs + flags + bus + nats + smtp Caddyfile + pure-Go sqlite3 driver)
 xcaddy build --with github.com/infogulch/xtemplate/caddy/standard
 
 # leaner subset: pick desired providers (and a SQL driver) individually

--- a/caddy/standard/standard.go
+++ b/caddy/standard/standard.go
@@ -1,5 +1,5 @@
 // Package standard links the default set of dot-provider Caddyfile parsers
-// (sql, fs, flags, nats, smtp), the pure-Go sqlite3 database/sql driver, and the
+// (sql, fs, flags, nats, smtp, bus), the pure-Go sqlite3 database/sql driver, and the
 // xtemplate caddy module in a single opt-in import.
 //
 // Usage:
@@ -13,6 +13,7 @@ package standard
 
 import (
 	_ "github.com/infogulch/xtemplate/caddy"
+	_ "github.com/infogulch/xtemplate/providers/dotbus/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotflags/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotfs/caddyfile"
 	_ "github.com/infogulch/xtemplate/providers/dotnats/caddyfile"

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"github.com/infogulch/xtemplate/app/git"
 
+	_ "github.com/infogulch/xtemplate/providers/dotbus"
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"github.com/infogulch/xtemplate/app"
 
+	_ "github.com/infogulch/xtemplate/providers/dotbus"
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"

--- a/cmd/watchfs/main.go
+++ b/cmd/watchfs/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"github.com/infogulch/xtemplate/app/watchfs"
 
+	_ "github.com/infogulch/xtemplate/providers/dotbus"
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"

--- a/docs/how-to/custom-build.md
+++ b/docs/how-to/custom-build.md
@@ -13,7 +13,7 @@ xtemplate's packaging is intentionally like Caddy's: a thin `main` that blank-im
 | Git CLI | `./cmd/git` | Poll a Git remote; shallow-clone + reload on new commit |
 | Docker image | `infogulch/xtemplate` | Builds `./cmd` (plain) with listen default `:80` |
 | Caddy module (lean) | `caddy` | Core handler + Caddyfile surface; add `providers/*/caddyfile` as needed |
-| Caddy module (standard) | `caddy/standard` | Lean + Caddyfile parsers for sql, fs, flags, nats, smtp + pure-Go sqlite3 driver |
+| Caddy module (standard) | `caddy/standard` | Lean + Caddyfile parsers for sql, fs, flags, bus, nats, smtp + pure-Go sqlite3 driver |
 
 Which variant to pick (including Caddy standard vs lean builds): [Deployment modes](../reference/deployment-modes.md).
 
@@ -37,6 +37,7 @@ package main
 import (
 	"github.com/infogulch/xtemplate/app/watchfs"
 
+	_ "github.com/infogulch/xtemplate/providers/dotbus"
 	_ "github.com/infogulch/xtemplate/providers/dotflags"
 	_ "github.com/infogulch/xtemplate/providers/dotfs"
 	_ "github.com/infogulch/xtemplate/providers/dotnats"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -80,6 +80,11 @@ Providers are a list of objects with a `type` discriminator and a `name` (dot fi
       }
     },
     {
+      "type": "bus",
+      "name": "Bus",
+      "buffer": 16
+    },
+    {
       "type": "nats",
       "name": "Nats",
       "nats_config": {
@@ -112,10 +117,11 @@ Providers are a list of objects with a `type` discriminator and a `name` (dot fi
 | `sql` | `providers/dotsql` | `name`, `driver`, `connstr`, `max_open_conns` |
 | `fs` | `providers/dotfs` | `name`, `path`, `writable` (bool, default false) |
 | `flags` | `providers/dotflags` | `name`, `values` (string map) |
+| `bus` | `providers/dotbus` | `name`, `buffer` (int, default 16) |
 | `nats` | `providers/dotnats` | `name`, `nats_config`, … |
 | `smtp` | `providers/dotsmtp` | `name`, `host`, `from`, `port`, `username`, `password`, `auth`, `tls`, `helo`, `max_recipients`, `max_message_bytes`, `send_timeout` |
 
-Unknown `type` values error at load with a hint to import the registering package. The standard CLI blank-imports all five core providers.
+Unknown `type` values error at load with a hint to import the registering package. The standard CLI blank-imports all core providers.
 
 For `smtp`, `send_timeout` is a Go `time.Duration`: in JSON it is a **nanosecond integer** (for example `30000000000` for 30s). Caddyfile `send_timeout 30s` is converted for you.
 

--- a/docs/reference/dot-context.md
+++ b/docs/reference/dot-context.md
@@ -107,6 +107,23 @@ Optional `writable: true` exposes multipart upload (`ReceiveFiles`). Full API: p
 
 Package: [`providers/dotflags`](https://pkg.go.dev/github.com/infogulch/xtemplate/providers/dotflags). Provider type: `"flags"`. Exposes a fixed map of strings (feature flags, env labels, versions) without a separate config file format inside templates.
 
+### In-process broadcast with `bus`
+
+Package: [`providers/dotbus`](https://pkg.go.dev/github.com/infogulch/xtemplate/providers/dotbus). Provider type: `"bus"`. Process-local multi-producer multi-consumer topic fan-out for SSE and live UI — no external broker.
+
+Typical field name: `.Bus`. Optional `buffer` is the per-subscriber channel capacity (default 16). Publish is best-effort: if a subscriber's buffer is full, that message is dropped for that subscriber (never blocks the publisher). Prefer `nats` when you need multi-process delivery, request/reply, or durable streams.
+
+```html
+{{define "SSE /events"}}{{range .Bus.Subscribe "messages"}}{{$.Flush.SendSSE "" .}}{{end}}{{end}}
+{{define "POST /messages"}}{{.Req.ParseForm}}{{.Bus.Publish "messages" (.Req.FormValue "msg")}}ok{{end}}
+```
+
+JSON:
+
+```json
+{ "type": "bus", "name": "Bus", "buffer": 16 }
+```
+
 ### Messaging with `nats`
 
 Package: [`providers/dotnats`](https://pkg.go.dev/github.com/infogulch/xtemplate/providers/dotnats). Provider type: `"nats"`. Send, request/reply, and stream-oriented patterns. Integration tests under [`test/templates/nats/`](../../test/templates/nats/) exercise a working configuration with an in-process server.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -48,7 +48,7 @@ Domain terms for xtemplate. Behavior and APIs live in the rest of the [docs](../
 
 **Builtin provider**: Supplied by xtemplate: `.X` and `.Req` always; `.Resp` on buffered handlers; `.Flush` on flushing handlers.
 
-**Core provider**: Package under `xtemplate/providers` (`sql`, `fs`, `flags`, `nats`, `smtp`).
+**Core provider**: Package under `xtemplate/providers` (`sql`, `fs`, `flags`, `bus`, `nats`, `smtp`).
 
 **Standard provider set**: Types included in release binaries (`cmd/*`). For Caddy, blank-import `xtemplate/caddy/standard`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ the listed URL.
 | Example | Feature | Run task | Port | URL |
 |---|---|---|---|---|
 | [`contacts`](./contacts/) | File-based routing + custom method routes + `.DB` (sqlite CRUD) | `mise run example-contacts` | 9001 | <http://localhost:9001/> |
-| [`sse-chat`](./sse-chat/) | Server-Sent Events with `.Flush` (live updates) | `mise run example-sse-chat` | 9002 | <http://localhost:9002/> |
+| [`sse-chat`](./sse-chat/) | Multi-user SSE chat with `.Bus` + `.Flush` | `mise run example-sse-chat` | 9002 | <http://localhost:9002/> |
 | [`blog`](./blog/) | Optimal asset serving: content-hash cache-busting + Subresource Integrity (`.X.StaticFileHash`) | `mise run example-blog` | 9003 | <http://localhost:9003/> |
 | [`filebrowser`](./filebrowser/) | Filesystem dot provider (`.FS` list/read + `ReceiveFiles` upload) | `mise run example-filebrowser` | 9004 | <http://localhost:9004/> |
 | [`embedded`](./embedded/) | Single-binary deployment with `//go:embed` (custom build) | `mise run example-embedded` | 9005 | <http://localhost:9005/> |

--- a/examples/sse-chat/README.md
+++ b/examples/sse-chat/README.md
@@ -1,9 +1,14 @@
 # sse-chat
 
-A live feed served over Server-Sent Events. The page opens an `EventSource`
-to `/events`; the `{{define "SSE /events"}}` template pushes a bounded stream
-of `data:` messages using `.Flush`, one every `delay` ms for `count`
-iterations (query params, defaults 20 / 1000ms).
+Multi-user realtime chat over Server-Sent Events and the in-process
+[`bus`](../../docs/reference/dot-context.md#in-process-broadcast-with-bus)
+provider.
+
+- The page opens an `EventSource` to `/events`, which ranges
+  `{{.Bus.Subscribe "messages"}}` and streams each message with `.Flush.SendSSE`.
+- The form `POST`s to `/messages`, which calls
+  `{{.Bus.Publish "messages" …}}`.
+- Open two browser tabs to see messages fan out to every connected client.
 
 ```sh
 mise run example-sse-chat
@@ -11,5 +16,6 @@ mise run example-sse-chat
 
 Then open http://localhost:9002/
 
-Extension idea: swap the server-generated counter for messages published to a
-NATS subject for real multi-user chat (needs extra `nats` config; not done here).
+For multi-process messaging (or request/reply, durable streams), swap `bus`
+for the [`nats`](../../docs/reference/dot-context.md#messaging-with-nats)
+provider instead.

--- a/examples/sse-chat/config.json
+++ b/examples/sse-chat/config.json
@@ -1,1 +1,9 @@
-{ "templates_dir": "templates" }
+{
+  "templates_dir": "templates",
+  "providers": [
+    {
+      "type": "bus",
+      "name": "Bus"
+    }
+  ]
+}

--- a/examples/sse-chat/templates/index.html
+++ b/examples/sse-chat/templates/index.html
@@ -1,20 +1,48 @@
 <!doctype html>
-<title>SSE live feed</title>
+<title>SSE chat</title>
 <link rel="stylesheet" href="/assets/app.css" />
-<h1>Live feed</h1>
+<h1>Chat</h1>
+<p>
+    Multi-user realtime chat over Server-Sent Events and the in-process
+    <code>bus</code> provider. Open this page in two tabs to try it.
+</p>
+<form id="send">
+    <input id="msg" name="msg" autofocus required placeholder="Type a message" autocomplete="off" />
+    <button>Send</button>
+</form>
 <ul id="feed"></ul>
 <script>
-    new EventSource("/events?count=3&delay=200").onmessage = (e) => {
+    const feed = document.getElementById("feed");
+    const form = document.getElementById("send");
+    const input = document.getElementById("msg");
+
+    const es = new EventSource("/events");
+    es.onmessage = (e) => {
         const li = document.createElement("li");
         li.textContent = e.data;
-        document.getElementById("feed").appendChild(li);
+        feed.prepend(li);
+    };
+
+    form.onsubmit = async (e) => {
+        e.preventDefault();
+        const msg = input.value.trim();
+        if (!msg) return;
+        await fetch("/messages", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ msg }),
+        });
+        form.reset();
+        input.focus();
     };
 </script>
+
+{{- /* Stream bus messages to every connected client. */}}
 {{- define "SSE /events"}}
-{{- $count := .Req.URL.Query.Get `count` | default `20` | atoi}}
-{{- $delay := .Req.URL.Query.Get `delay` | default `1000` | atoi}}
-{{- range $i := .Flush.Repeat $count}}
-    {{- $.Flush.SendSSE "" (printf "message %d" $i)}}
-    {{- $.Flush.Sleep $delay}}
+{{- $.Flush.SendSSE "" "connected"}}
+{{- range .Bus.Subscribe "messages"}}{{$.Flush.SendSSE "" .}}{{end}}
 {{- end}}
+
+{{- define "POST /messages"}}
+{{- .Req.ParseForm}}{{.Bus.Publish "messages" (.Req.FormValue "msg")}}ok
 {{- end}}

--- a/examples/sse-chat/tests/sse.hurl
+++ b/examples/sse-chat/tests/sse.hurl
@@ -1,21 +1,23 @@
+# Chat page renders
 GET http://localhost:8080/
 
 HTTP 200
 [Asserts]
-body contains "Live feed"
+body contains "Chat"
 body contains "EventSource"
+body contains "bus"
+
+# Publishing a message succeeds (fan-out is verified by the lightpanda SSE test)
+POST http://localhost:8080/messages
+[FormParams]
+msg: hello from hurl
+
+HTTP 200
+[Asserts]
+body == "ok"
 
 # The SSE endpoint requires the text/event-stream Accept header; without it the
 # flushing handler refuses with 406.
-GET http://localhost:8080/events?count=1&delay=10
+GET http://localhost:8080/events
 
 HTTP 406
-
-# With the right Accept header it streams events as text/event-stream.
-GET http://localhost:8080/events?count=3&delay=10
-Accept: text/event-stream
-
-HTTP 200
-Content-Type: text/event-stream
-[Asserts]
-body contains "data: message 0"

--- a/providers.go
+++ b/providers.go
@@ -38,7 +38,7 @@ func resolveProviders(raw []json.RawMessage) ([]DotConfig, error) {
 		ctor, ok := registry[probe.Type]
 		if !ok {
 			switch probe.Type {
-			case "sql", "fs", "flags", "nats", "smtp":
+			case "sql", "fs", "flags", "nats", "smtp", "bus":
 				return nil, fmt.Errorf("xtemplate: unknown provider type %q; add it by importing github.com/infogulch/xtemplate/providers/dot%s", probe.Type, probe.Type)
 			default:
 				return nil, fmt.Errorf("xtemplate: unknown provider type %q; ensure the provider package that registers type %q is imported", probe.Type, probe.Type)

--- a/providers/dotbus/bus.go
+++ b/providers/dotbus/bus.go
@@ -1,0 +1,124 @@
+package dotbus
+
+import (
+	"fmt"
+	"sync"
+)
+
+// DefaultBuffer is the per-subscriber channel capacity when config Buffer is 0.
+const DefaultBuffer = 16
+
+var errClosed = fmt.Errorf("bus closed")
+
+// Bus is a process-local multi-producer multi-consumer topic fan-out.
+//
+// Publish is best-effort: if a subscriber's buffer is full, that message is
+// dropped for that subscriber (never blocks the publisher). Suitable for SSE
+// and other live UI fan-out; not a durable queue.
+type Bus struct {
+	mu      sync.Mutex
+	buffer  int
+	topics  map[string]map[chan string]struct{}
+	reverse map[chan string]map[string]struct{}
+	closed  bool
+}
+
+// New returns a Bus. buffer is the capacity of each subscriber channel;
+// values less than 1 are treated as DefaultBuffer.
+func New(buffer int) *Bus {
+	if buffer < 1 {
+		buffer = DefaultBuffer
+	}
+	return &Bus{
+		buffer:  buffer,
+		topics:  make(map[string]map[chan string]struct{}),
+		reverse: make(map[chan string]map[string]struct{}),
+	}
+}
+
+// Publish sends msg to all current subscribers of topic. Slow subscribers
+// (full buffer) skip the message. Returns an error if the bus is shut down or
+// topic is empty.
+func (b *Bus) Publish(topic, msg string) error {
+	if topic == "" {
+		return fmt.Errorf("bus: topic is required")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return errClosed
+	}
+	for ch := range b.topics[topic] {
+		select {
+		case ch <- msg:
+		default:
+			// drop for this subscriber
+		}
+	}
+	return nil
+}
+
+// Subscribe registers a new subscriber on topic and returns its receive
+// channel. The channel is closed when Unsubscribe is called or the bus is shut
+// down. topic must be non-empty.
+func (b *Bus) Subscribe(topic string) (<-chan string, error) {
+	if topic == "" {
+		return nil, fmt.Errorf("bus: topic is required")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, errClosed
+	}
+	ch := make(chan string, b.buffer)
+	if b.topics[topic] == nil {
+		b.topics[topic] = make(map[chan string]struct{})
+	}
+	b.topics[topic][ch] = struct{}{}
+	if b.reverse[ch] == nil {
+		b.reverse[ch] = make(map[string]struct{})
+	}
+	b.reverse[ch][topic] = struct{}{}
+	return ch, nil
+}
+
+// Unsubscribe removes ch from all topics and closes it. Safe to call more than
+// once or after Shutdown; subsequent calls are no-ops.
+func (b *Bus) Unsubscribe(ch <-chan string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.removeLocked(ch)
+}
+
+func (b *Bus) removeLocked(ch <-chan string) {
+	for c, topics := range b.reverse {
+		if (<-chan string)(c) != ch {
+			continue
+		}
+		for t := range topics {
+			delete(b.topics[t], c)
+			if len(b.topics[t]) == 0 {
+				delete(b.topics, t)
+			}
+		}
+		delete(b.reverse, c)
+		close(c)
+		return
+	}
+}
+
+// Shutdown closes every subscriber channel and rejects further Publish/Subscribe.
+// Safe to call more than once.
+func (b *Bus) Shutdown() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for c := range b.reverse {
+		close(c)
+	}
+	b.topics = make(map[string]map[chan string]struct{})
+	b.reverse = make(map[chan string]map[string]struct{})
+}

--- a/providers/dotbus/bus_test.go
+++ b/providers/dotbus/bus_test.go
@@ -1,0 +1,202 @@
+package dotbus
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPublishSubscribe(t *testing.T) {
+	b := New(4)
+	defer b.Shutdown()
+
+	ch, err := b.Subscribe("chat")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := b.Publish("chat", "hello"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got != "hello" {
+			t.Fatalf("got %q, want hello", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestMPMCFanout(t *testing.T) {
+	b := New(64)
+	defer b.Shutdown()
+
+	const nSub = 5
+	const nPub = 3
+	const nMsg = 10
+	want := nPub * nMsg
+
+	var readerWG sync.WaitGroup
+	counts := make([]int, nSub)
+	for i := 0; i < nSub; i++ {
+		ch, err := b.Subscribe("t")
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		readerWG.Add(1)
+		go func(idx int, ch <-chan string) {
+			defer readerWG.Done()
+			for range ch {
+				counts[idx]++
+				if counts[idx] >= want {
+					return
+				}
+			}
+		}(i, ch)
+	}
+
+	var pubWG sync.WaitGroup
+	for i := 0; i < nPub; i++ {
+		pubWG.Add(1)
+		go func() {
+			defer pubWG.Done()
+			for j := 0; j < nMsg; j++ {
+				if err := b.Publish("t", "x"); err != nil {
+					t.Errorf("Publish: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	pubWG.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		readerWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout; counts=%v want %d each", counts, want)
+	}
+	for i, c := range counts {
+		if c != want {
+			t.Errorf("sub %d got %d, want %d", i, c, want)
+		}
+	}
+}
+
+func TestDropWhenFull(t *testing.T) {
+	b := New(1)
+	defer b.Shutdown()
+
+	ch, err := b.Subscribe("t")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	// Fill buffer without reading.
+	if err := b.Publish("t", "a"); err != nil {
+		t.Fatalf("Publish a: %v", err)
+	}
+	// Must not block; second message dropped for this sub.
+	done := make(chan struct{})
+	go func() {
+		_ = b.Publish("t", "b")
+		_ = b.Publish("t", "c")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on full subscriber")
+	}
+	got := <-ch
+	if got != "a" {
+		t.Fatalf("first msg = %q, want a", got)
+	}
+}
+
+func TestTopicIsolation(t *testing.T) {
+	b := New(2)
+	defer b.Shutdown()
+
+	a, err := b.Subscribe("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := b.Subscribe("b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Publish("a", "only-a"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case msg := <-a:
+		if msg != "only-a" {
+			t.Fatalf("got %q", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on a")
+	}
+	select {
+	case msg := <-other:
+		t.Fatalf("topic b unexpectedly got %q", msg)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestUnsubscribeClosesChannel(t *testing.T) {
+	b := New(2)
+	defer b.Shutdown()
+
+	ch, err := b.Subscribe("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Unsubscribe(ch)
+	if _, ok := <-ch; ok {
+		t.Fatal("expected closed channel")
+	}
+	// Idempotent.
+	b.Unsubscribe(ch)
+}
+
+func TestShutdown(t *testing.T) {
+	b := New(2)
+	ch, err := b.Subscribe("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Shutdown()
+	if _, ok := <-ch; ok {
+		t.Fatal("expected closed channel after Shutdown")
+	}
+	if err := b.Publish("t", "x"); err == nil {
+		t.Fatal("Publish after Shutdown should error")
+	}
+	if _, err := b.Subscribe("t"); err == nil {
+		t.Fatal("Subscribe after Shutdown should error")
+	}
+	b.Shutdown() // idempotent
+}
+
+func TestEmptyTopic(t *testing.T) {
+	b := New(1)
+	defer b.Shutdown()
+	if err := b.Publish("", "x"); err == nil {
+		t.Fatal("Publish empty topic should error")
+	}
+	if _, err := b.Subscribe(""); err == nil {
+		t.Fatal("Subscribe empty topic should error")
+	}
+}
+
+func TestDefaultBuffer(t *testing.T) {
+	b := New(0)
+	defer b.Shutdown()
+	if b.buffer != DefaultBuffer {
+		t.Fatalf("buffer = %d, want %d", b.buffer, DefaultBuffer)
+	}
+}

--- a/providers/dotbus/caddyfile/caddyfile.go
+++ b/providers/dotbus/caddyfile/caddyfile.go
@@ -1,0 +1,55 @@
+// Package caddyfile registers the bus dot-provider for Caddyfile use.
+// Blank-import this package to enable `provider bus <field> { }` blocks.
+//
+// Covered: buffer.
+package caddyfile
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	xtc "github.com/infogulch/xtemplate/caddy"
+	_ "github.com/infogulch/xtemplate/providers/dotbus"
+)
+
+type busCaddyfile struct{}
+
+func init() { caddy.RegisterModule(busCaddyfile{}) }
+
+func (busCaddyfile) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "xtemplate.providers.bus",
+		New: func() caddy.Module { return new(busCaddyfile) },
+	}
+}
+
+var _ xtc.CaddyfileProvider = (*busCaddyfile)(nil)
+
+func (busCaddyfile) ParseCaddyfile(h httpcaddyfile.Helper) (json.RawMessage, error) {
+	type result struct {
+		Buffer int `json:"buffer,omitempty"`
+	}
+	cfg := &result{}
+	for h.NextBlock(1) {
+		switch h.Val() {
+		case "buffer":
+			var s string
+			if !h.AllArgs(&s) {
+				return nil, h.ArgErr()
+			}
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				return nil, h.Errf("buffer must be an integer: %v", err)
+			}
+			if n < 0 {
+				return nil, h.Errf("buffer must be >= 0")
+			}
+			cfg.Buffer = n
+		default:
+			return nil, h.Errf("unknown bus provider option '%s'", h.Val())
+		}
+	}
+	return json.Marshal(cfg)
+}

--- a/providers/dotbus/caddyfile/caddyfile_test.go
+++ b/providers/dotbus/caddyfile/caddyfile_test.go
@@ -1,0 +1,76 @@
+package caddyfile_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+
+	xtc "github.com/infogulch/xtemplate/caddy"
+	_ "github.com/infogulch/xtemplate/providers/dotbus/caddyfile"
+)
+
+func parse(t *testing.T, body string) (json.RawMessage, error) {
+	t.Helper()
+	input := "outer {\n\tprovider bus Bus {\n" + body + "\n\t}\n}"
+	h := httpcaddyfile.Helper{}.WithDispenser(caddyfile.NewTestDispenser(input))
+	h.Next()       // "outer"
+	h.NextBlock(0) // → "provider"
+	h.NextArg()    // "bus"
+	h.NextArg()    // "Bus"
+	mi, err := caddy.GetModule("xtemplate.providers.bus")
+	if err != nil {
+		t.Fatalf("GetModule: %v", err)
+	}
+	return mi.New().(xtc.CaddyfileProvider).ParseCaddyfile(h)
+}
+
+func TestBusCaddyfile_HappyPath(t *testing.T) {
+	raw, err := parse(t, "\t\tbuffer 64")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var got struct {
+		Buffer int `json:"buffer"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Buffer != 64 {
+		t.Errorf("buffer = %d, want 64", got.Buffer)
+	}
+}
+
+func TestBusCaddyfile_EmptyBlock(t *testing.T) {
+	raw, err := parse(t, "")
+	if err != nil {
+		t.Fatalf("ParseCaddyfile: %v", err)
+	}
+	var got struct {
+		Buffer int `json:"buffer"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Buffer != 0 {
+		t.Errorf("buffer = %d, want 0 (default)", got.Buffer)
+	}
+}
+
+func TestBusCaddyfile_Errors(t *testing.T) {
+	cases := map[string]string{
+		"missing value":  "\t\tbuffer",
+		"non-integer":    "\t\tbuffer nope",
+		"negative":       "\t\tbuffer -1",
+		"unknown option": "\t\tbogus 1",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parse(t, body); err == nil {
+				t.Errorf("expected error for %q", name)
+			}
+		})
+	}
+}

--- a/providers/dotbus/dotbus.go
+++ b/providers/dotbus/dotbus.go
@@ -1,0 +1,95 @@
+// Package dotbus implements the bus core dot provider: a process-local
+// multi-producer multi-consumer topic fan-out for templates.
+//
+// Use it for single-process SSE and live UI messaging. Prefer the nats
+// provider when you need multi-process delivery, request/reply, persistence,
+// or JetStream.
+package dotbus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/infogulch/xtemplate"
+)
+
+func init() {
+	xtemplate.Register("bus", func() xtemplate.DotConfig { return &DotBusConfig{} })
+}
+
+// WithBus creates an [xtemplate.Option] that adds a bus dot provider.
+// buffer is the per-subscriber channel capacity; 0 means [DefaultBuffer].
+func WithBus(name string, buffer int) xtemplate.Option {
+	return func(c *xtemplate.Config) error {
+		c.Providers = append(c.Providers, &DotBusConfig{Name: name, Buffer: buffer})
+		return nil
+	}
+}
+
+// DotBusConfig configures an xtemplate dot field for in-process topic fan-out.
+type DotBusConfig struct {
+	// Name is the dot field name (required), e.g. "Bus" → {{.Bus}}.
+	Name string `json:"name"`
+	// Buffer is the per-subscriber channel capacity. 0 means DefaultBuffer.
+	Buffer int `json:"buffer"`
+
+	bus *Bus
+}
+
+var _ xtemplate.DotConfig = &DotBusConfig{}
+
+// FieldName returns the dot field name contributed by this provider.
+func (d *DotBusConfig) FieldName() string { return d.Name }
+
+// Init validates config, creates the bus, and shuts it down when ctx is cancelled
+// (instance reload / server stop).
+func (d *DotBusConfig) Init(ctx context.Context) error {
+	if d.Name == "" {
+		return fmt.Errorf("bus: name is required")
+	}
+	if d.Buffer < 0 {
+		return fmt.Errorf("bus: buffer must be >= 0")
+	}
+	d.bus = New(d.Buffer)
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			d.bus.Shutdown()
+		}()
+	}
+	return nil
+}
+
+// Value returns the per-request [DotBus] bound to the request context.
+func (d *DotBusConfig) Value(r xtemplate.Request) (any, error) {
+	return &DotBus{bus: d.bus, ctx: r.R.Context()}, nil
+}
+
+// DotBus is the per-request template value for the bus provider.
+type DotBus struct {
+	bus *Bus
+	ctx context.Context
+}
+
+// Publish sends message to all current subscribers of topic. Slow subscribers
+// may drop the message; Publish never blocks on them.
+func (d *DotBus) Publish(topic, message string) error {
+	return d.bus.Publish(topic, message)
+}
+
+// Subscribe returns a channel of messages on topic. The channel is closed when
+// the request context is cancelled or the bus shuts down, so
+// {{range .Bus.Subscribe "topic"}} ends cleanly for SSE handlers.
+func (d *DotBus) Subscribe(topic string) (<-chan string, error) {
+	ch, err := d.bus.Subscribe(topic)
+	if err != nil {
+		return nil, err
+	}
+	if done := d.ctx.Done(); done != nil {
+		go func() {
+			<-done
+			d.bus.Unsubscribe(ch)
+		}()
+	}
+	return ch, nil
+}

--- a/providers/dotbus/dotbus_test.go
+++ b/providers/dotbus/dotbus_test.go
@@ -1,0 +1,214 @@
+package dotbus_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/infogulch/xtemplate"
+	"github.com/infogulch/xtemplate/providers/dotbus"
+)
+
+func buildInstance(t *testing.T, files map[string]string, opts ...xtemplate.Option) *xtemplate.Instance {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	for name, content := range files {
+		if err := afero.WriteFile(fs, name, []byte(content), 0644); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	cfg := xtemplate.New()
+	all := append([]xtemplate.Option{xtemplate.WithTemplateFS(fs)}, opts...)
+	inst, _, _, err := cfg.Instance(all...)
+	if err != nil {
+		t.Fatalf("Instance: %v", err)
+	}
+	return inst
+}
+
+// sseRecorder is an http.ResponseWriter that signals when SSE data is written.
+// Safe for concurrent Write + wait (unlike reading httptest.ResponseRecorder.Body).
+type sseRecorder struct {
+	header http.Header
+	code   int
+	mu     sync.Mutex
+	body   strings.Builder
+	saw    chan struct{}
+	once   sync.Once
+}
+
+func newSSERecorder() *sseRecorder {
+	return &sseRecorder{
+		header: make(http.Header),
+		saw:    make(chan struct{}),
+	}
+}
+
+func (r *sseRecorder) Header() http.Header        { return r.header }
+func (r *sseRecorder) WriteHeader(statusCode int) { r.code = statusCode }
+func (r *sseRecorder) Flush()                     {}
+func (r *sseRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	r.body.Write(p)
+	r.mu.Unlock()
+	if bytes.Contains(p, []byte("data:")) {
+		r.once.Do(func() { close(r.saw) })
+	}
+	return len(p), nil
+}
+
+func (r *sseRecorder) BodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.String()
+}
+
+func TestDotBus_PublishSubscribeTemplate(t *testing.T) {
+	inst := buildInstance(t,
+		map[string]string{
+			"pub.html": `{{.Bus.Publish "messages" "hi"}}ok`,
+			"index.html": `{{define "SSE /events"}}` +
+				`{{range .Bus.Subscribe "messages"}}{{$.Flush.SendSSE "" .}}{{end}}{{end}}`,
+		},
+		dotbus.WithBus("Bus", 8),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := newSSERecorder()
+	r := httptest.NewRequest(http.MethodGet, "/events", nil).WithContext(ctx)
+	r.Header.Set("Accept", "text/event-stream")
+
+	done := make(chan struct{})
+	go func() {
+		inst.ServeHTTP(w, r)
+		close(done)
+	}()
+
+	// Wait for the SSE handler to subscribe, then publish.
+	time.Sleep(50 * time.Millisecond)
+	pw := httptest.NewRecorder()
+	inst.ServeHTTP(pw, httptest.NewRequest(http.MethodGet, "/pub", nil))
+	if pw.Code != http.StatusOK {
+		cancel()
+		<-done
+		t.Fatalf("publish status = %d body %q", pw.Code, pw.Body.String())
+	}
+
+	select {
+	case <-w.saw:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatalf("sse body = %q, want data: hi", w.BodyString())
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not return after cancel")
+	}
+	if !strings.Contains(w.BodyString(), "data: hi") {
+		t.Fatalf("sse body = %q, want data: hi", w.BodyString())
+	}
+}
+
+func TestDotBusConfig_Init(t *testing.T) {
+	cfg := &dotbus.DotBusConfig{Name: "Bus"}
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := cfg.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	v, err := cfg.Value(xtemplate.Request{
+		R: httptest.NewRequest(http.MethodGet, "/", nil),
+	})
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	dot := v.(*dotbus.DotBus)
+	ch, err := dot.Subscribe("t")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := dot.Publish("t", "m"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got != "m" {
+			t.Fatalf("got %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+	cancel() // shuts down bus via Init's ctx watcher
+	select {
+	case _, ok := <-ch:
+		if ok {
+			for ok {
+				_, ok = <-ch
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for close after Shutdown")
+	}
+}
+
+func TestDotBusConfig_Validation(t *testing.T) {
+	if err := (&dotbus.DotBusConfig{}).Init(context.Background()); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if err := (&dotbus.DotBusConfig{Name: "B", Buffer: -1}).Init(context.Background()); err == nil {
+		t.Fatal("expected error for negative buffer")
+	}
+}
+
+func TestDotBus_WithBusOption(t *testing.T) {
+	inst := buildInstance(t,
+		map[string]string{
+			"index.html": `{{.Bus.Publish "x" "y"}}ok`,
+		},
+		dotbus.WithBus("Bus", 0),
+	)
+	w := httptest.NewRecorder()
+	inst.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusOK || w.Body.String() != "ok" {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestDotBus_RequestCancelUnsubscribes(t *testing.T) {
+	cfg := &dotbus.DotBusConfig{Name: "Bus", Buffer: 4}
+	if err := cfg.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	reqCtx, cancel := context.WithCancel(context.Background())
+	v, err := cfg.Value(xtemplate.Request{
+		R: httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dot := v.(*dotbus.DotBus)
+	ch, err := dot.Subscribe("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected closed channel after request cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for unsubscribe")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `providers/dotbus`: process-local topic fan-out (`Publish` / `Subscribe`) for SSE and live UI, with optional buffer and drop-on-full backpressure.
- Register bus in standard CLI and caddy builds; document configuration and dot context.
- Convert the `sse-chat` example from a synthetic counter stream to multi-user chat over `.Bus`.
- Drop the lightpanda EventSource polyfill (fixed upstream in lightpanda-io/browser#2975) and retest the chat page with native EventSource: inject a POST after the `connected` greeting and `--wait-script` until the token appears in the DOM. Hurl still covers page/POST/406; multi-sub bus fan-out stays in `providers/dotbus` tests.

Closes #107

## Test plan

- [x] `mise run test-example-sse-chat` (hurl + lightpanda)
- [x] `mise run test` / CI green
- [x] Manual: `mise run example-sse-chat`, open two tabs, send messages