### PR TITLE
Redesign the provider API

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -13,6 +13,10 @@ golangci-lint = "latest"
 "go:github.com/caddyserver/xcaddy/cmd/xcaddy" = "latest"
 "github:lightpanda-io/browser" = "nightly"
 
+# Align Go module/build paths on local dev and CI.
+[env]
+GOPATH = "{{env.HOME}}/.local/go"
+
 [tasks.lint]
 description = "Run lint checks"
 depends = ["lint-nu", "lint-go"]

--- a/.github/actions/ci-cache/action.yml
+++ b/.github/actions/ci-cache/action.yml
@@ -22,7 +22,7 @@ runs:
           ~/.cache/go-build
           ~/.local/go/pkg/mod
           dist/buildx-cache
-        key: prebuild-${{ steps.prebuild.outputs.key }}
+        key: prebuild-v2-${{ steps.prebuild.outputs.key }}
 
     - name: Run prebuild (downloads modules, precompiles deps, exports build cache)
       if: steps.cache.outputs.cache-hit != 'true'
@@ -37,4 +37,4 @@ runs:
           ~/.cache/go-build
           ~/.local/go/pkg/mod
           dist/buildx-cache
-        key: prebuild-${{ steps.prebuild.outputs.key }}
+        key: prebuild-v2-${{ steps.prebuild.outputs.key }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: ci
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,7 +19,9 @@ jobs:
           # Full history + tags so `git describe` can derive the version.
           fetch-depth: 0
 
-      # Installs tools pinned by mise, from cache if available
+      # Installs tools pinned by mise, from cache if available. Also exports
+      # project [env] (notably GOPATH=~/.local/go) into GITHUB_ENV so Go and the
+      # prebuild cache paths agree.
       - uses: jdx/mise-action@v4
 
       # prebuild exports the Docker deps cache via `--cache-to type=local`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking: Change dot provider API**
+  - Rename base interface `DotConfig` → `Provider`
+  - Renamed extension interfaces: `InitDotProvider` → `Initializer`,
+    `CleanupDotProvider` → `Finalizer`
+  - Added `Closer` interface for instance-stop-time cleanup
+  - `Provider` now requires `Prototype() any` for field type inference,
+    replacing mock `Value` call at instance build
+  - Remove request bag struct passed to `Value`, replaced with separate
+    `http.ResponseWriter`/`*http.Request` args. Instance context can be retained
+    from `Init` when needed.
+  - `Instance.Close` runs `Closer` on reload/stop; Server calls it when retiring
+    an instance.
+
 ## [v0.10.1] - 2026-07-20
 
 New core providers and writable filesystem uploads.

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	CrossOrigin CrossOriginConfig `json:"crossorigin" arg:"-"`
 
 	ProvidersRaw []json.RawMessage `json:"providers,omitempty" arg:"-"`
-	Providers    []DotConfig       `json:"-" arg:"-"`
+	Providers    []Provider        `json:"-" arg:"-"`
 
 	// Encodings to pre-compress static files into at load time. Supported values:
 	// "gzip", "zstd", "br". Default empty (no pre-compression).
@@ -179,7 +179,7 @@ func WithHandler(pattern string, h http.Handler) Option {
 	}
 }
 
-func WithProvider(p DotConfig) Option {
+func WithProvider(p Provider) Option {
 	return func(c *Config) error {
 		c.Providers = append(c.Providers, p)
 		return nil

--- a/docs/adr/0003-caddyfile-provider-dispatch-via-caddy-module-registry.md
+++ b/docs/adr/0003-caddyfile-provider-dispatch-via-caddy-module-registry.md
@@ -8,7 +8,7 @@ Caddyfile `provider <type> <field> { }` is a JSON adapter only. If a provider re
 
 ## Considered options
 
-- **`ParseBlock` on `DotConfig` in the provider package.** Rejected: couples every provider to Caddy.
+- **`ParseBlock` on `Provider` in the provider package.** Rejected: couples every provider to Caddy.
 - **Core `BlockParser` hiding Caddy helpers.** Rejected: Caddyfile concepts leak into `xtemplate`; authors lose real `httpcaddyfile.Helper` APIs.
 - **Separate Caddy-side register map.** Rejected: prefer Caddy’s module registry (same pattern as `xtemplate.funcs.*`).
 

--- a/docs/adr/0006-reflection-assembled-dot-context.md
+++ b/docs/adr/0006-reflection-assembled-dot-context.md
@@ -4,7 +4,7 @@ status: accepted
 
 # Dot context is a reflection-built struct of provider fields
 
-The per-request dot context is not a fixed Go type. When an instance is built, `makeDot` walks the configured dot providers, calls each `Value` once with a mock request to learn the concrete Go type of its dot field, and `reflect.StructOf` builds a struct type whose exported fields are those names and types. Per request, a pooled value of that type is filled by calling `Value` again with the real request; optional `CleanupDotProvider` runs after execution (success or failure).
+The per-request dot context is not a fixed Go type. When an instance is built, `makeDot` walks the configured dot providers, calls each `Prototype` once to learn the concrete Go type of its dot field, and `reflect.StructOf` builds a struct type whose exported fields are those names and types. Per request, a pooled value of that type is filled by calling `Value(w, r)`; optional `Finalizer` runs after execution (success or failure). Instance lifetime context is not passed to `Value`; providers that need it retain it from `Init`.
 
 This is how an open-ended set of core, custom, and registered provider packages can contribute fields like `.DB` or `.Shop` without the `xtemplate` package knowing those types at compile time, and without forcing templates onto a map-based or `interface{}`-only `.`.
 
@@ -14,11 +14,12 @@ This is how an open-ended set of core, custom, and registered provider packages 
 - **Map or `map[string]any` as `.`.** Rejected: loses method sets and typed field access that `html/template` and authors rely on (e.g. `.DB.QueryRows`, `.Shop.Product`); errors become stringly-typed key mistakes, and accidentally mutating the map would corrupt the dot context and cause confusing errors.
 - **Code generation of a context type per binary.** Rejected: extra build step for every new configuration; the reflection approach keeps "import provider + configure" as the only assembly step (see ADR-0001 / 0002).
 - **Infer types only from `FieldName` + generics.** Rejected: Go generics would not allow customization of the user-chosen field names or multiple fields from the same provider.
+- **Infer types by calling `Value` with a mock request.** Rejected in favor of `Prototype`: dual-purpose `Value` forced providers to return a typed zero even when request data was missing, and mock-call errors were discarded.
 
 ## Consequences
 
-- `Value` must return a stable, non-nil concrete type. The load-time mock call discards the value and uses only `reflect.TypeOf`; a nil interface (including `return nil, err` during inference) cannot define a field type and fails instance build. Providers that need request data must still return a typed zero value of the right type when the mock request is inadequate.
+- `Prototype` must return a stable, non-nil concrete type. The load-time call discards the value and uses only `reflect.TypeOf`; a nil interface cannot define a field type and fails instance build.
 - Field names come from `FieldName()` and must be unique on an instance; collisions fail the build.
-- Method sets visible to templates are those available on the *value* returned by `Value`, not of the provider config type itself.
-- Cleanup order and partial unwind on construction failure are part of the contract: providers that open resources in `Value` should implement `CleanupDotProvider` (as the SQL core provider does for transactions).
+- Method sets visible to templates are those available on the *value* returned by `Value`, not of the provider config type itself. `Value` should return the same concrete type as `Prototype`.
+- Finalize order and partial unwind on construction failure are part of the contract: providers that open resources in `Value` should implement `Finalizer` (as the SQL core provider does for transactions).
 - Two dots are assembled per instance (buffered vs flushing provider lists); see ADR-0005. The reflection mechanism is shared; the field lists differ by `.Resp` vs `.Flush`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,7 +37,7 @@ Reference the [glossary](reference/glossary.md) for xtemplate terminology.
 
 ### Builtin providers (dot context)
 
-- [`dot.go`](/dot.go) - `DotConfig` / dot provider interface
+- [`dot.go`](/dot.go) - `Provider` and extension interfaces
 - [`dot_instance.go`](/dot_instance.go) - `.X` (instance)
 - [`dot_req.go`](/dot_req.go) - `.Req`
 - [`dot_resp.go`](/dot_resp.go) - `.Resp` (buffered handlers)
@@ -45,7 +45,7 @@ Reference the [glossary](reference/glossary.md) for xtemplate terminology.
 
 ### Provider authoring
 
-- [`dot.go`](/dot.go) - `DotConfig` / `CleanupDotProvider`
+- [`dot.go`](/dot.go) - provider interfaces (see Builtin providers above)
 - [`providers.go`](/providers.go) - Provider type registry (`Register`, `resolveProviders`)
 - [`providers/dotsql/sql.go`](/providers/dotsql/sql.go) - Core SQL provider package
 - [`examples/dotprovider/`](/examples/dotprovider/) - Custom provider example

--- a/docs/how-to/create-a-provider.md
+++ b/docs/how-to/create-a-provider.md
@@ -6,21 +6,21 @@ A complete runnable example: [`examples/dotprovider`](../../examples/dotprovider
 
 ## Ways to attach a provider
 
-Every path implements the same `DotConfig` interface. Pick by how the provider is configured:
+Every path implements the same `Provider` interface. Pick by how the provider is configured:
 
 - **Custom provider** - construct it in Go and pass `WithProvider` (or put it on `Config.Providers`). Best for app-specific code next to `main`. Not selectable from JSON or Caddyfile.
 - **Provider package** - self-register a type from `init()` so JSON can decode `"type"`. Required when the binary must resolve providers from config (CLI or Caddy JSON).
 - **Caddyfile provider** - a Caddy module under `xtemplate.providers.*` that parses `provider <type> <field> { }` into JSON.
 
-## 1. Implement DotConfig
+## 1. Implement Provider
 
-Every dot provider has a field name, a one-time init step (when an instance is built), and a per-request value step:
+Every dot provider has a field name, a prototype for type inference, and a per-request value step:
 
 ```go
-type DotConfig interface {
-	FieldName() string            // name of the dot field, e.g. "Shop" → {{.Shop}}
-	Init(context.Context) error   // once per instance load / reload
-	Value(Request) (any, error)   // once per request; assigned to the dot field
+type Provider interface {
+	FieldName() string                    // name of the dot field, e.g. "Shop" → {{.Shop}}
+	Prototype() any                       // non-nil typed zero; used only for reflection at instance build
+	Value(http.ResponseWriter, *http.Request) (any, error) // once per request; assigned to the dot field
 }
 ```
 
@@ -28,23 +28,36 @@ type DotConfig interface {
 // shopProvider is the provider config (here: no extra settings).
 type shopProvider struct{}
 
-func (shopProvider) FieldName() string                    { return "Shop" }
-func (shopProvider) Init(context.Context) error           { return nil }
-func (shopProvider) Value(xtemplate.Request) (any, error) { return Shop{}, nil }
+func (shopProvider) FieldName() string                         { return "Shop" }
+func (shopProvider) Prototype() any                            { return Shop{} }
+func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) { return Shop{}, nil }
 ```
 
 - `FieldName` chooses the dot field on the dot context. Two providers on one instance must not share a field name.
+- `Prototype` must return a non-nil value of the same concrete type that `Value` returns. It is discarded after type inference.
 - Methods on the value returned by `Value` are callable from templates (`{{.Shop.Product 1}}`).
 
-> [!important]
-> `Value` must return a stable, non-nil concrete type. When an instance is built, xtemplate calls `Value` once with a mock request to infer the field type via reflection. A `nil` return fails the load.
-
-Optional: implement `CleanupDotProvider` for per-request teardown (commit / rollback, close handles). The core SQL provider uses this.
+Optional: implement `Initializer` for instance-scoped setup (open connections, validate config). The instance context is cancelled on reload/stop; retain it on the provider if request-time code must observe reload/stop (do not expect it on `Value`).
 
 ```go
-type CleanupDotProvider interface {
-	DotConfig
-	Cleanup(v any, err error) error // v is the value Value returned for the request
+type Initializer interface {
+	Init(context.Context) error // save ctx on the provider if needed later
+}
+```
+
+Optional: implement `Finalizer` for per-request teardown after template execution (commit / rollback, close handles, write buffered status). The core SQL provider uses this.
+
+```go
+type Finalizer interface {
+	Finalize(v any, err error) error // v is the value Value returned for the request
+}
+```
+
+Optional: implement `Closer` to release instance-scoped resources when the instance is retired (reload or stop). Prefer this when the provider owns connections; context cancellation alone is easy to forget.
+
+```go
+type Closer interface {
+	Close() error
 }
 ```
 
@@ -61,20 +74,24 @@ app.Main(xtemplate.WithProvider(shopProvider{}))
 
 On instance load, xtemplate builds the dot context struct to include your field. On every request, `Value` runs before the template executes.
 
-No JSON `"type"` is involved: the provider config is already a constructed `DotConfig` value.
+No JSON `"type"` is involved: the provider is already a constructed `Provider` value.
 
 ## 2b. Provider package: xtemplate registry (`providers.go`)
 
-To configure the provider from JSON (`"providers": [{ "type": "…" }]`) which supports both xtemplate CLI and Caddy JSON config, in a provider package, call `xtemplate.Register` with a value that implements `xtemplate.DotConfig` and supports go JSON [un]marshalling:
+To configure the provider from JSON (`"providers": [{ "type": "…" }]`) which supports both xtemplate CLI and Caddy JSON config, in a provider package, call `xtemplate.Register` with a value that implements `xtemplate.Provider` and supports go JSON [un]marshalling:
 
 ```go
 package shop
 
-import "github.com/infogulch/xtemplate"
+import (
+	"net/http"
+
+	"github.com/infogulch/xtemplate"
+)
 
 func init() {
 	// "shop" is the provider type - JSON discriminator and Caddyfile token.
-	xtemplate.Register("shop", func() xtemplate.DotConfig {
+	xtemplate.Register("shop", func() xtemplate.Provider {
 		return &ShopConfig{}
 	})
 }
@@ -85,9 +102,9 @@ type ShopConfig struct {
 	// … other settings …
 }
 
-func (c *ShopConfig) FieldName() string          { return c.Name }
-func (c *ShopConfig) Init(ctx context.Context) error { /* … */ return nil }
-func (c *ShopConfig) Value(r xtemplate.Request) (any, error) {
+func (c *ShopConfig) FieldName() string { return c.Name }
+func (c *ShopConfig) Prototype() any    { return Shop{} }
+func (c *ShopConfig) Value(http.ResponseWriter, *http.Request) (any, error) {
 	return Shop{}, nil
 }
 ```
@@ -95,7 +112,7 @@ func (c *ShopConfig) Value(r xtemplate.Request) (any, error) {
 Here's how the registry works:
 
 1. `Register(name, ctor)`: maps a provider type string to a constructor. Call only from `init()`; duplicate names panic.
-2. At instance build, `resolveProviders` peeks each entry’s `"type"`, looks up the constructor, re-decodes into the concrete type, and returns `[]DotConfig` for the instance. See [`providers.go`](../../providers.go).
+2. At instance build, `resolveProviders` peeks each entry’s `"type"`, looks up the constructor, re-decodes into the concrete type, and returns `[]Provider` for the instance. See [`providers.go`](../../providers.go).
 
 Opt the type into a binary by blank-importing the package (same pattern as the standard provider set under `cmd`):
 
@@ -127,7 +144,7 @@ Mirror the layout under `providers/dotsql/caddyfile/` and blank-import it in you
 package main
 
 import (
-	"context"
+	"net/http"
 
 	"github.com/infogulch/xtemplate"
 	"github.com/infogulch/xtemplate/app"
@@ -148,9 +165,11 @@ func (Shop) Products() []Product {
 
 type shopProvider struct{}
 
-func (shopProvider) FieldName() string                    { return "Shop" }
-func (shopProvider) Init(context.Context) error           { return nil }
-func (shopProvider) Value(xtemplate.Request) (any, error) { return Shop{}, nil }
+func (shopProvider) FieldName() string { return "Shop" }
+func (shopProvider) Prototype() any    { return Shop{} }
+func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return Shop{}, nil
+}
 
 func main() {
 	app.Main(xtemplate.WithProvider(shopProvider{}))

--- a/docs/reference/dot-context.md
+++ b/docs/reference/dot-context.md
@@ -83,7 +83,7 @@ Package: [`providers/dotsql`](https://pkg.go.dev/github.com/infogulch/xtemplate/
 </ul>
 ```
 
-Methods include `QueryRows`, `QueryRow`, `QueryVal`, `Exec`, and explicit `Commit`. Each request gets a value that opens a transaction on first use and commits on success or rolls back on error (via `CleanupDotProvider`).
+Methods include `QueryRows`, `QueryRow`, `QueryVal`, `Exec`, and explicit `Commit`. Each request gets a value that opens a transaction on first use and commits on success or rolls back on error (via `Finalizer`).
 
 Default builds include the `sqlite3` driver ([ncruces/go-sqlite3](https://github.com/ncruces/go-sqlite3)); other drivers need a [custom build](../how-to/custom-build.md).
 
@@ -145,4 +145,4 @@ Typical field name: `.Email`. Config requires `host` and `from` (default sender)
 
 ## Custom providers
 
-Implement `xtemplate.DotConfig` and attach with `WithProvider` (or register a provider type for JSON/Caddyfile). See [How to create a custom dot provider](../how-to/create-a-provider.md) and [`examples/dotprovider`](../../examples/dotprovider/).
+Implement `xtemplate.Provider` and attach with `WithProvider` (or register a provider type for JSON/Caddyfile). See [How to create a custom dot provider](../how-to/create-a-provider.md) and [`examples/dotprovider`](../../examples/dotprovider/).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -40,7 +40,7 @@ Domain terms for xtemplate. Behavior and APIs live in the rest of the [docs](../
 
 ## Providers
 
-**Dot provider**: Contributes one named field on the per-request dot (`{{.Field}}`): type, field name, init, and per-request value.
+**Dot provider**: Contributes one named field on the per-request dot (`{{.Field}}`): field name, prototype type, optional init/finalize/close, and per-request value. Implements `Provider`; optional hooks via `Initializer`, `Finalizer`, `Closer`.
 
 **Dot field**: That field's name (`FieldName`); unique per instance.
 
@@ -56,6 +56,6 @@ Domain terms for xtemplate. Behavior and APIs live in the rest of the [docs](../
 
 **Custom provider**: User Go code via `Config.Providers` / `WithProvider`, not via the type registry.
 
-**Provider config**: Type, field name, and type-specific settings (JSON via the registry, or a constructed `DotConfig`).
+**Provider config**: Type, field name, and type-specific settings (JSON via the registry, or a constructed `Provider`).
 
 **Caddyfile provider**: Caddy module `xtemplate.providers.*` that parses `provider <type> <field> { }` into config JSON.

--- a/dot.go
+++ b/dot.go
@@ -4,44 +4,69 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"sync"
 )
 
-type Request struct {
-	DotConfig
-	ServerCtx context.Context
-	W         http.ResponseWriter
-	R         *http.Request
-}
-
-type DotConfig interface {
+// Provider contributes one named field on the per-request dot context.
+//
+// Lifecycle:
+//   - [FieldName] and [Prototype] are used when an instance is built.
+//   - Optional [Initializer.Init] runs once per instance load (after config
+//     decode, before Prototype is used for type assembly). Save the instance
+//     context there if request-time code must observe reload/stop.
+//   - [Value] runs once per request (and for INIT templates).
+//   - Optional [Finalizer.Finalize] runs after template execution.
+//   - Optional [Closer.Close] runs when the instance is retired (reload/stop).
+//
+// Optional hooks are separate capability interfaces (like [http.Flusher]); they
+// do not embed [Provider]. Assert them when needed.
+type Provider interface {
+	// FieldName is the exported struct field on the dot (e.g. "Shop" → {{.Shop}}).
 	FieldName() string
+	// Prototype returns a non-nil value of the field type. It is called once
+	// when building the instance solely to infer the type via reflection; the
+	// returned value is discarded. It must not depend on request data.
+	Prototype() any
+	// Value returns the value to assign to this provider's field for a request.
+	// w and r are the HTTP response writer and request (same as http.Handler).
+	// Request-scoped context is r.Context(); instance lifetime context should
+	// have been saved during [Initializer.Init] if needed.
+	Value(w http.ResponseWriter, r *http.Request) (any, error)
+}
+
+// Initializer is an optional capability for instance-scoped setup (open DB,
+// connect, validate config, etc.). Init runs once per instance load with the
+// instance context (cancelled on reload/stop). Providers that need that context
+// at request time should retain it on the provider value.
+type Initializer interface {
 	Init(context.Context) error
-	// Value returns the value to assign to this provider's dot field for a
-	// given request. It must return a stable, non-nil concrete type: makeDot
-	// calls it once with a mock request purely to infer the field type via
-	// reflection, so a nil return (e.g. on error during inference) cannot be
-	// used to build the dot struct.
-	Value(Request) (any, error)
 }
 
-type CleanupDotProvider interface {
-	DotConfig
-	Cleanup(any, error) error
+// Finalizer is an optional capability for work after template execution
+// (commit/rollback, close request-scoped handles, write buffered response
+// headers/status). value is what Value returned for the request; err is the
+// template/construction error so far. The returned error replaces err for
+// subsequent finalizers and the handler.
+type Finalizer interface {
+	Finalize(value any, err error) error
 }
 
-func makeDot(dps []DotConfig) (dot, error) {
+// Closer is an optional capability for releasing instance-scoped resources when
+// the instance is retired (reload or stop). Prefer Close over relying solely on
+// context cancellation when the provider owns connections or similar handles.
+type Closer interface {
+	Close() error
+}
+
+func makeDot(dps []Provider) (dot, error) {
 	fields := make([]reflect.StructField, 0, len(dps))
-	cleanups := []cleanup{}
-	mockHttpRequest := httptest.NewRequest("GET", "/", nil)
+	finalizers := []finalizer{}
 	for i, dp := range dps {
-		mockRequest := Request{dp, context.Background(), mockResponseWriter{}, mockHttpRequest}
-		a, _ := dp.Value(mockRequest)
+		a := dp.Prototype()
 		t := reflect.TypeOf(a)
 		if t == nil {
-			return dot{}, fmt.Errorf("dot provider %q (%T) returned a nil value during type inference; Value must return a non-nil typed value", dp.FieldName(), dp)
+			return dot{}, fmt.Errorf("dot provider %q (%T) Prototype returned nil; Prototype must return a non-nil typed value", dp.FieldName(), dp)
 		}
 		f := reflect.StructField{
 			Name:      dp.FieldName(),
@@ -49,37 +74,37 @@ func makeDot(dps []DotConfig) (dot, error) {
 			Anonymous: false, // alas
 		}
 		fields = append(fields, f)
-		if cdp, ok := dp.(CleanupDotProvider); ok {
-			cleanups = append(cleanups, cleanup{i, cdp})
+		if fdp, ok := dp.(Finalizer); ok {
+			finalizers = append(finalizers, finalizer{i, fdp})
 		}
 	}
 	typ := reflect.StructOf(fields)
-	return dot{dps, cleanups, &sync.Pool{New: func() any { v := reflect.New(typ).Elem(); return &v }}}, nil
+	return dot{dps, finalizers, &sync.Pool{New: func() any { v := reflect.New(typ).Elem(); return &v }}}, nil
 }
 
 type dot struct {
-	dps      []DotConfig
-	cleanups []cleanup
-	pool     *sync.Pool
+	dps        []Provider
+	finalizers []finalizer
+	pool       *sync.Pool
 }
 
-type cleanup struct {
+type finalizer struct {
 	idx int
-	CleanupDotProvider
+	Finalizer
 }
 
-func (d *dot) value(sctx context.Context, w http.ResponseWriter, r *http.Request) (val *reflect.Value, err error) {
+func (d *dot) value(w http.ResponseWriter, r *http.Request) (val *reflect.Value, err error) {
 	val = d.pool.Get().(*reflect.Value)
 	val.SetZero()
 	for i, dp := range d.dps {
 		var a any
-		a, err = dp.Value(Request{dp, sctx, w, r})
+		a, err = dp.Value(w, r)
 		if err != nil {
 			err = fmt.Errorf("failed to construct dot value for %s (%v): %w", dp.FieldName(), dp, err)
 			// Unwind the providers that were already constructed for this request
 			// (only fields before index i have been set) so they don't leak
-			// resources, e.g. an open DB transaction whose Cleanup rolls back.
-			err = cleanpSlice(d.cleanups[:i], val, err)
+			// resources, e.g. an open DB transaction whose Finalize rolls back.
+			err = finalizeSlice(d.finalizers[:i], val, err)
 			val.SetZero()
 			d.pool.Put(val)
 			val = nil
@@ -90,31 +115,19 @@ func (d *dot) value(sctx context.Context, w http.ResponseWriter, r *http.Request
 	return
 }
 
-// cleanpSlice runs Cleanup for every provided CleanupDotProvider, folding
-// any cleanup errors into err. d.cleanups is ordered by ascending field index,
-// so it can stop early.
-func cleanpSlice(cleanups []cleanup, v *reflect.Value, err error) error {
-	for _, cleanup := range cleanups {
-		err = cleanup.Cleanup(v.Field(cleanup.idx).Interface(), err)
+// finalizeSlice runs Finalize for every provided Finalizer, folding any
+// finalize errors into err. d.finalizers is ordered by ascending field index,
+// so it can stop early on partial unwind.
+func finalizeSlice(finalizers []finalizer, v *reflect.Value, err error) error {
+	for _, f := range finalizers {
+		err = f.Finalize(v.Field(f.idx).Interface(), err)
 	}
 	return err
 }
 
 func (d *dot) cleanup(v *reflect.Value, err error) error {
-	err = cleanpSlice(d.cleanups, v, err)
+	err = finalizeSlice(d.finalizers, v, err)
 	v.SetZero()
 	d.pool.Put(v)
 	return err
 }
-
-type mockResponseWriter struct{}
-
-var _ http.ResponseWriter = mockResponseWriter{}
-
-func (mockResponseWriter) Header() http.Header { return http.Header{} }
-
-func (m mockResponseWriter) Write(b []byte) (int, error) {
-	return 0, fmt.Errorf("this is a mock http.ResponseWriter")
-}
-
-func (m mockResponseWriter) WriteHeader(statusCode int) {}

--- a/dot_flush.go
+++ b/dot_flush.go
@@ -9,26 +9,40 @@ import (
 	"time"
 )
 
-type dotFlushProvider struct{}
+// dotFlushProvider contributes .Flush. It stores the instance context in Init
+// so Sleep/Repeat/WaitForServerStop can observe reload/stop without receiving
+// that context on every Value call.
+type dotFlushProvider struct {
+	serverCtx context.Context
+}
 
-func (dotFlushProvider) FieldName() string            { return "Flush" }
-func (dotFlushProvider) Init(_ context.Context) error { return nil }
-func (dotFlushProvider) Value(r Request) (any, error) {
-	f, ok := r.W.(flusher)
+func (dotFlushProvider) FieldName() string { return "Flush" }
+func (dotFlushProvider) Prototype() any    { return &DotFlush{} }
+
+func (p *dotFlushProvider) Init(ctx context.Context) error {
+	p.serverCtx = ctx
+	return nil
+}
+
+func (p *dotFlushProvider) Value(w http.ResponseWriter, r *http.Request) (any, error) {
+	f, ok := w.(flusher)
 	if !ok {
 		return &DotFlush{}, fmt.Errorf("response writer could not cast to http.Flusher")
 	}
-	return &DotFlush{flusher: f, serverCtx: r.ServerCtx, requestCtx: r.R.Context()}, nil
+	return &DotFlush{flusher: f, serverCtx: p.serverCtx, requestCtx: r.Context()}, nil
 }
 
-func (dotFlushProvider) Cleanup(v any, err error) error {
+func (dotFlushProvider) Finalize(v any, err error) error {
 	if err == nil {
 		v.(*DotFlush).flusher.Flush()
 	}
 	return err
 }
 
-var _ CleanupDotProvider = dotFlushProvider{}
+var (
+	_ Initializer = (*dotFlushProvider)(nil)
+	_ Finalizer   = (*dotFlushProvider)(nil)
+)
 
 type flusher interface {
 	http.ResponseWriter

--- a/dot_instance.go
+++ b/dot_instance.go
@@ -2,10 +2,10 @@ package xtemplate
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"path"
 )
 
@@ -13,18 +13,20 @@ type dotXProvider struct {
 	instance *Instance
 }
 
-func (dotXProvider) FieldName() string            { return "X" }
-func (dotXProvider) Init(_ context.Context) error { return nil }
-func (p dotXProvider) Value(Request) (any, error) { return DotX(p), nil }
+func (dotXProvider) FieldName() string { return "X" }
+func (p dotXProvider) Prototype() any  { return DotX{} }
+func (p dotXProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return DotX(p), nil
+}
 
-func (dotXProvider) Cleanup(_ any, err error) error {
+func (dotXProvider) Finalize(_ any, err error) error {
 	if errors.As(err, &ReturnError{}) {
 		return nil
 	}
 	return err
 }
 
-var _ CleanupDotProvider = dotXProvider{}
+var _ Finalizer = dotXProvider{}
 
 // DotX is used as the field at .X in all template invocations.
 type DotX struct {

--- a/dot_req.go
+++ b/dot_req.go
@@ -1,19 +1,18 @@
 package xtemplate
 
 import (
-	"context"
 	"net/http"
 )
 
 type dotReqProvider struct{}
 
-func (dotReqProvider) FieldName() string            { return "Req" }
-func (dotReqProvider) Init(_ context.Context) error { return nil }
-func (dotReqProvider) Value(r Request) (any, error) {
-	return DotReq{r.R}, nil
+func (dotReqProvider) FieldName() string { return "Req" }
+func (dotReqProvider) Prototype() any    { return DotReq{} }
+func (dotReqProvider) Value(_ http.ResponseWriter, r *http.Request) (any, error) {
+	return DotReq{r}, nil
 }
 
-var _ DotConfig = dotReqProvider{}
+var _ Provider = dotReqProvider{}
 
 // DotReq is used as the .Req field for template invocations with an associated
 // request, and contains the current HTTP request struct which can be used to

--- a/dot_resp.go
+++ b/dot_resp.go
@@ -1,7 +1,6 @@
 package xtemplate
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -14,18 +13,20 @@ import (
 
 type dotRespProvider struct{}
 
-func (dotRespProvider) FieldName() string            { return "Resp" }
-func (dotRespProvider) Init(_ context.Context) error { return nil }
-func (dotRespProvider) Value(r Request) (any, error) {
+func (dotRespProvider) FieldName() string { return "Resp" }
+func (dotRespProvider) Prototype() any {
+	return DotResp{Header: make(http.Header)}
+}
+func (dotRespProvider) Value(w http.ResponseWriter, r *http.Request) (any, error) {
 	return DotResp{
 		Header: make(http.Header),
 		status: http.StatusOK,
-		w:      r.W, r: r.R,
-		log: GetLogger(r.R.Context()),
+		w:      w, r: r,
+		log: GetLogger(r.Context()),
 	}, nil
 }
 
-func (dotRespProvider) Cleanup(v any, err error) error {
+func (dotRespProvider) Finalize(v any, err error) error {
 	d := v.(DotResp)
 	if d.served {
 		// The response was already fully written by ServeContent (which calls
@@ -44,7 +45,7 @@ func (dotRespProvider) Cleanup(v any, err error) error {
 	return err
 }
 
-var _ CleanupDotProvider = dotRespProvider{}
+var _ Finalizer = dotRespProvider{}
 
 // DotResp is used as the .Resp field in buffered template invocations.
 type DotResp struct {

--- a/dot_test.go
+++ b/dot_test.go
@@ -1,30 +1,17 @@
 package xtemplate
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 )
 
-type testGreeting struct {
-	Greeting string
-}
-
-type testDotProvider struct {
-	field string
-}
-
-func (p testDotProvider) FieldName() string          { return p.field }
-func (p testDotProvider) Init(context.Context) error { return nil }
-func (p testDotProvider) Value(Request) (any, error) {
-	return testGreeting{Greeting: "hi"}, nil
-}
-
 func TestMakeDotHappyPath(t *testing.T) {
-	provider := testDotProvider{field: "Test"}
-	d, err := makeDot([]DotConfig{provider})
+	// Reuse testProvider from providers_test.go (same package).
+	provider := &testProvider{Name: "Test", Val: "hi"}
+	d, err := makeDot([]Provider{provider})
 	if err != nil {
 		t.Fatalf("unexpected error from makeDot: %v", err)
 	}
@@ -32,7 +19,7 @@ func TestMakeDotHappyPath(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
 
-	val, err := d.value(context.Background(), w, r)
+	val, err := d.value(w, r)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,75 +37,73 @@ func TestMakeDotHappyPath(t *testing.T) {
 	if field.Name != "Test" {
 		t.Errorf("field name = %q, want %q", field.Name, "Test")
 	}
-	if field.Type != reflect.TypeOf(testGreeting{}) {
-		t.Errorf("field type = %v, want %v", field.Type, reflect.TypeOf(testGreeting{}))
+	if field.Type != reflect.TypeOf("") {
+		t.Errorf("field type = %v, want string", field.Type)
 	}
-
-	greeting := val.Field(0).FieldByName("Greeting")
-	if !greeting.IsValid() {
-		t.Fatal("expected the embedded struct to have a Greeting field")
-	}
-	if greeting.String() != "hi" {
-		t.Errorf("Greeting = %q, want %q", greeting.String(), "hi")
+	if got := val.Field(0).String(); got != "hi" {
+		t.Errorf("field value = %q, want %q", got, "hi")
 	}
 }
 
-// testNilDotProvider is a DotConfig whose Value returns (nil, err), simulating
-// a custom provider that fails during type inference.
-type testNilDotProvider struct {
+// testNilPrototypeProvider is a Provider whose Prototype returns nil.
+type testNilPrototypeProvider struct {
 	field string
 }
 
-func (p testNilDotProvider) FieldName() string          { return p.field }
-func (p testNilDotProvider) Init(context.Context) error { return nil }
-func (p testNilDotProvider) Value(Request) (any, error) {
+func (p testNilPrototypeProvider) FieldName() string { return p.field }
+func (p testNilPrototypeProvider) Prototype() any    { return nil }
+func (p testNilPrototypeProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
 	return nil, fmt.Errorf("boom")
 }
 
-// cleanupRecorder captures whether Cleanup ran and the error it received.
-type cleanupRecorder struct {
+// finalizeRecorder captures whether Finalize ran and the error it received.
+type finalizeRecorder struct {
 	called bool
 	gotErr error
 }
 
-// recordingCleanupProvider is a CleanupDotProvider that records its Cleanup
+// recordingFinalizeProvider is a Finalizer that records its Finalize
 // invocation, used to verify partially-constructed dot values are unwound.
-type recordingCleanupProvider struct {
+type recordingFinalizeProvider struct {
 	field string
-	rec   *cleanupRecorder
+	rec   *finalizeRecorder
 }
 
-func (p recordingCleanupProvider) FieldName() string          { return p.field }
-func (p recordingCleanupProvider) Init(context.Context) error { return nil }
-func (p recordingCleanupProvider) Value(Request) (any, error) { return struct{}{}, nil }
-func (p recordingCleanupProvider) Cleanup(_ any, err error) error {
+func (p recordingFinalizeProvider) FieldName() string { return p.field }
+func (p recordingFinalizeProvider) Prototype() any    { return struct{}{} }
+func (p recordingFinalizeProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return struct{}{}, nil
+}
+func (p recordingFinalizeProvider) Finalize(_ any, err error) error {
 	p.rec.called = true
 	p.rec.gotErr = err
 	return err
 }
 
-var _ CleanupDotProvider = recordingCleanupProvider{}
+var _ Finalizer = recordingFinalizeProvider{}
 
-// failingValueProvider returns a typed value (so makeDot can infer its field
-// type) but always fails at request time, simulating a provider whose Value
-// errors after earlier providers have already been constructed.
+// failingValueProvider returns a typed prototype but always fails at request
+// time, simulating a provider whose Value errors after earlier providers have
+// already been constructed.
 type failingValueProvider struct {
 	field string
 	err   error
 }
 
-func (p failingValueProvider) FieldName() string          { return p.field }
-func (p failingValueProvider) Init(context.Context) error { return nil }
-func (p failingValueProvider) Value(Request) (any, error) { return struct{}{}, p.err }
+func (p failingValueProvider) FieldName() string { return p.field }
+func (p failingValueProvider) Prototype() any    { return struct{}{} }
+func (p failingValueProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return struct{}{}, p.err
+}
 
-// TestDotValuePartialCleanup verifies that when a provider's Value fails partway
-// through constructing a dot value, the providers that were already built get
-// their Cleanup called (with the construction error) so they don't leak
-// resources such as open DB transactions.
-func TestDotValuePartialCleanup(t *testing.T) {
-	rec := &cleanupRecorder{}
-	d, err := makeDot([]DotConfig{
-		recordingCleanupProvider{field: "A", rec: rec},
+// TestDotValuePartialFinalize verifies that when a provider's Value fails
+// partway through constructing a dot value, the providers that were already
+// built get their Finalize called (with the construction error) so they don't
+// leak resources such as open DB transactions.
+func TestDotValuePartialFinalize(t *testing.T) {
+	rec := &finalizeRecorder{}
+	d, err := makeDot([]Provider{
+		recordingFinalizeProvider{field: "A", rec: rec},
 		failingValueProvider{field: "B", err: fmt.Errorf("boom")},
 	})
 	if err != nil {
@@ -127,7 +112,7 @@ func TestDotValuePartialCleanup(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
-	val, err := d.value(context.Background(), w, r)
+	val, err := d.value(w, r)
 	if err == nil {
 		t.Fatal("expected an error when a later provider's Value fails, got nil")
 	}
@@ -135,23 +120,23 @@ func TestDotValuePartialCleanup(t *testing.T) {
 		t.Errorf("expected a nil dot value on error, got %v", val)
 	}
 	if !rec.called {
-		t.Error("expected the earlier provider's Cleanup to run during partial unwind")
+		t.Error("expected the earlier provider's Finalize to run during partial unwind")
 	}
 	if rec.gotErr == nil {
-		t.Error("expected the construction error to be passed to Cleanup")
+		t.Error("expected the construction error to be passed to Finalize")
 	}
 }
 
-func TestMakeDotNilProvider(t *testing.T) {
+func TestMakeDotNilPrototype(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("makeDot panicked instead of returning an error: %v", r)
 		}
 	}()
 
-	provider := testNilDotProvider{field: "Test"}
-	_, err := makeDot([]DotConfig{provider})
+	provider := testNilPrototypeProvider{field: "Test"}
+	_, err := makeDot([]Provider{provider})
 	if err == nil {
-		t.Fatal("expected a non-nil error when a provider returns a nil value, got nil")
+		t.Fatal("expected a non-nil error when Prototype returns nil, got nil")
 	}
 }

--- a/examples/dotprovider/README.md
+++ b/examples/dotprovider/README.md
@@ -14,8 +14,10 @@ Then open http://localhost:9006/.
 
 ## Writing a dot provider
 
-Implement `xtemplate.DotConfig` (`FieldName() string`, `Init(context.Context) error`,
-`Value(xtemplate.Request) (any, error)`), then register the instance via
-`xtemplate.WithProvider(p)` passed to `app.Main`. `FieldName` is the dot field
-name (`Shop` here); `Value` returns the value assigned to `{{.Shop}}` for each
-request. See `main.go`.
+Implement `xtemplate.Provider` (`FieldName() string`, `Prototype() any`,
+`Value(http.ResponseWriter, *http.Request) (any, error)`), then register the
+instance via `xtemplate.WithProvider(p)` passed to `app.Main`. `FieldName` is
+the dot field name (`Shop` here); `Prototype` is a typed zero for reflection;
+`Value` returns the value assigned to `{{.Shop}}` for each request. `Init` is
+optional (save the instance context there if request-time code needs it). See
+`main.go`.

--- a/examples/dotprovider/main.go
+++ b/examples/dotprovider/main.go
@@ -2,14 +2,15 @@
 // exposes hardcoded in-memory data to templates as {{.Shop}}, which can range
 // over products and look one up by id.
 //
-// To write a dot provider: implement xtemplate.DotConfig (FieldName, Init,
-// Value), then register the instance with xtemplate.WithProvider passed to
-// app.Main. FieldName is the dot field name; Value returns the value assigned
-// to that field for each request.
+// To write a dot provider: implement xtemplate.Provider (FieldName,
+// Prototype, Value), then register the instance with xtemplate.WithProvider
+// passed to app.Main. FieldName is the dot field name; Prototype is a typed
+// zero value for reflection; Value returns the value assigned to that field
+// for each request. Init is optional (Initializer).
 package main
 
 import (
-	"context"
+	"net/http"
 
 	"github.com/infogulch/xtemplate"
 	"github.com/infogulch/xtemplate/app"
@@ -42,12 +43,14 @@ func (Shop) Product(id int) Product {
 	return Product{}
 }
 
-// shopProvider implements xtemplate.DotConfig, attaching Shop under {{.Shop}}.
+// shopProvider implements xtemplate.Provider, attaching Shop under {{.Shop}}.
 type shopProvider struct{}
 
-func (shopProvider) FieldName() string                    { return "Shop" }
-func (shopProvider) Init(context.Context) error           { return nil }
-func (shopProvider) Value(xtemplate.Request) (any, error) { return Shop{}, nil }
+func (shopProvider) FieldName() string { return "Shop" }
+func (shopProvider) Prototype() any    { return Shop{} }
+func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return Shop{}, nil
+}
 
 func main() {
 	app.Main(xtemplate.WithProvider(shopProvider{}))

--- a/handlers.go
+++ b/handlers.go
@@ -29,7 +29,7 @@ func bufferingTemplateHandler(server *Instance, tmpl *template.Template) http.Ha
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := GetLogger(r.Context())
 
-		dot, err := server.bufferDot.value(server.config.Ctx, w, r)
+		dot, err := server.bufferDot.value(w, r)
 		if err != nil {
 			log.Error("failed to initialize dot value", slog.Any("error", err))
 			http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -65,7 +65,7 @@ func flushingTemplateHandler(server *Instance, tmpl *template.Template) http.Han
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		dot, err := server.flusherDot.value(server.config.Ctx, w, r)
+		dot, err := server.flusherDot.value(w, r)
 		if err != nil {
 			log.Error("failed to initialize dot value", slog.Any("error", err))
 			http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/instance.go
+++ b/instance.go
@@ -3,6 +3,7 @@ package xtemplate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -52,6 +53,10 @@ type Instance struct {
 
 	bufferDot  dot
 	flusherDot dot
+
+	// providers is the user/core provider list for this instance (not builtins).
+	// Used to call [Closer.Close] when the instance is retired.
+	providers []Provider
 }
 
 // Instance creates a new *Instance from the given config
@@ -153,9 +158,9 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 	dcInstance := dotXProvider{build.Instance}
 	dcReq := dotReqProvider{}
 	dcResp := dotRespProvider{}
-	dcFlush := dotFlushProvider{}
+	dcFlush := &dotFlushProvider{}
 
-	var dot []DotConfig
+	var dot []Provider
 
 	{
 		var err error
@@ -171,21 +176,36 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 			}
 			seen[name] = true
 		}
-		for _, d := range dot {
+		// Init user/core providers and any builtin that implements Initializer
+		// (e.g. Flush stores instance ctx for Sleep/WaitForServerStop).
+		toInit := slices.Concat([]Provider{dcInstance, dcReq, dcResp, dcFlush}, dot)
+		var opened []Provider
+		for _, d := range toInit {
+			idp, ok := d.(Initializer)
+			if !ok {
+				continue
+			}
 			start := time.Now()
-			err := d.Init(build.config.Ctx)
+			err := idp.Init(build.config.Ctx)
 			build.config.Logger.Debug("initialized provider", "name", d.FieldName(), "type", reflect.TypeOf(d).String(), "duration", time.Since(start))
 			if err != nil {
+				_ = closeProviders(opened)
 				return nil, nil, nil, fmt.Errorf("failed to initialize dot field '%s': %w", d.FieldName(), err)
 			}
+			opened = append(opened, d)
 		}
+		// Only user/core providers are closed on instance retire (builtins have
+		// no owned resources beyond the instance itself).
+		build.providers = dot
 	}
 
 	var err error
-	if build.bufferDot, err = makeDot(slices.Concat([]DotConfig{dcInstance, dcReq}, dot, []DotConfig{dcResp})); err != nil {
+	if build.bufferDot, err = makeDot(slices.Concat([]Provider{dcInstance, dcReq}, dot, []Provider{dcResp})); err != nil {
+		_ = closeProviders(dot)
 		return nil, nil, nil, fmt.Errorf("failed to build buffer dot: %w", err)
 	}
-	if build.flusherDot, err = makeDot(slices.Concat([]DotConfig{dcInstance, dcReq}, dot, []DotConfig{dcFlush})); err != nil {
+	if build.flusherDot, err = makeDot(slices.Concat([]Provider{dcInstance, dcReq}, dot, []Provider{dcFlush})); err != nil {
+		_ = closeProviders(dot)
 		return nil, nil, nil, fmt.Errorf("failed to build flusher dot: %w", err)
 	}
 
@@ -194,7 +214,7 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 		// with "INIT ".
 		makeDot := func() (*reflect.Value, error) {
 			w, r := httptest.NewRecorder(), httptest.NewRequest("", "/", nil)
-			return build.bufferDot.value(build.config.Ctx, w, r)
+			return build.bufferDot.value(w, r)
 		}
 		cleanup := build.bufferDot.cleanup
 		buf := new(bytes.Buffer)
@@ -254,6 +274,32 @@ var nextInstanceIdentity atomic.Int64
 // `xtemplate.instance`.
 func (x *Instance) Id() int64 {
 	return x.id
+}
+
+// Close releases instance-scoped provider resources ([Closer]).
+// It is safe to call more than once. [Server] calls Close when retiring an
+// instance on reload or stop; callers of [Config.Instance] should call Close
+// when the instance is no longer needed if providers own connections.
+func (x *Instance) Close() error {
+	if x == nil {
+		return nil
+	}
+	err := closeProviders(x.providers)
+	x.providers = nil
+	return err
+}
+
+func closeProviders(providers []Provider) error {
+	var errs []error
+	// Close in reverse init order so dependents shut down before dependencies.
+	for i := len(providers) - 1; i >= 0; i-- {
+		if c, ok := providers[i].(Closer); ok {
+			if err := c.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close %s: %w", providers[i].FieldName(), err))
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 var levelDebug2 slog.Level = slog.LevelDebug + 2

--- a/providers.go
+++ b/providers.go
@@ -9,12 +9,12 @@ import (
 // Written only in init(), read-only afterward.
 // ponytail: init()-only writes; race-free by Go's init happens-before guarantee.
 // Add a sync.RWMutex if runtime registration becomes supported.
-var registry = map[string]func() DotConfig{}
+var registry = map[string]func() Provider{}
 
 // Register makes a provider type available to resolveProviders. Call from init().
 // Panics on duplicate registration (names the type in the message; the registering
 // package is identified by the runtime's stack trace).
-func Register(name string, ctor func() DotConfig) {
+func Register(name string, ctor func() Provider) {
 	if _, exists := registry[name]; exists {
 		panic(fmt.Sprintf("xtemplate: provider type %q already registered", name))
 	}
@@ -23,11 +23,11 @@ func Register(name string, ctor func() DotConfig) {
 
 // resolveProviders decodes each raw JSON entry by peeking its "type" field,
 // looking up the constructor, and re-decoding into the concrete type.
-func resolveProviders(raw []json.RawMessage) ([]DotConfig, error) {
+func resolveProviders(raw []json.RawMessage) ([]Provider, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
-	out := make([]DotConfig, 0, len(raw))
+	out := make([]Provider, 0, len(raw))
 	for _, msg := range raw {
 		var probe struct {
 			Type string `json:"type"`

--- a/providers/dotbus/dotbus.go
+++ b/providers/dotbus/dotbus.go
@@ -9,12 +9,13 @@ package dotbus
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/infogulch/xtemplate"
 )
 
 func init() {
-	xtemplate.Register("bus", func() xtemplate.DotConfig { return &DotBusConfig{} })
+	xtemplate.Register("bus", func() xtemplate.Provider { return &DotBusConfig{} })
 }
 
 // WithBus creates an [xtemplate.Option] that adds a bus dot provider.
@@ -36,13 +37,19 @@ type DotBusConfig struct {
 	bus *Bus
 }
 
-var _ xtemplate.DotConfig = &DotBusConfig{}
+var (
+	_ xtemplate.Initializer = &DotBusConfig{}
+	_ xtemplate.Closer      = &DotBusConfig{}
+)
 
 // FieldName returns the dot field name contributed by this provider.
 func (d *DotBusConfig) FieldName() string { return d.Name }
 
-// Init validates config, creates the bus, and shuts it down when ctx is cancelled
-// (instance reload / server stop).
+// Prototype returns the per-request field type.
+func (d *DotBusConfig) Prototype() any { return &DotBus{} }
+
+// Init validates config and creates the bus. Call [Close] (or cancel the
+// instance context) to shut the bus down on reload/stop.
 func (d *DotBusConfig) Init(ctx context.Context) error {
 	if d.Name == "" {
 		return fmt.Errorf("bus: name is required")
@@ -60,9 +67,17 @@ func (d *DotBusConfig) Init(ctx context.Context) error {
 	return nil
 }
 
+// Close shuts down the bus. Safe to call more than once.
+func (d *DotBusConfig) Close() error {
+	if d.bus != nil {
+		d.bus.Shutdown()
+	}
+	return nil
+}
+
 // Value returns the per-request [DotBus] bound to the request context.
-func (d *DotBusConfig) Value(r xtemplate.Request) (any, error) {
-	return &DotBus{bus: d.bus, ctx: r.R.Context()}, nil
+func (d *DotBusConfig) Value(_ http.ResponseWriter, r *http.Request) (any, error) {
+	return &DotBus{bus: d.bus, ctx: r.Context()}, nil
 }
 
 // DotBus is the per-request template value for the bus provider.

--- a/providers/dotbus/dotbus_test.go
+++ b/providers/dotbus/dotbus_test.go
@@ -127,9 +127,7 @@ func TestDotBusConfig_Init(t *testing.T) {
 	if err := cfg.Init(ctx); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	v, err := cfg.Value(xtemplate.Request{
-		R: httptest.NewRequest(http.MethodGet, "/", nil),
-	})
+	v, err := cfg.Value(nil, httptest.NewRequest(http.MethodGet, "/", nil))
 	if err != nil {
 		t.Fatalf("Value: %v", err)
 	}
@@ -191,9 +189,7 @@ func TestDotBus_RequestCancelUnsubscribes(t *testing.T) {
 		t.Fatal(err)
 	}
 	reqCtx, cancel := context.WithCancel(context.Background())
-	v, err := cfg.Value(xtemplate.Request{
-		R: httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx),
-	})
+	v, err := cfg.Value(nil, httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/dotflags/flags.go
+++ b/providers/dotflags/flags.go
@@ -1,14 +1,14 @@
 package dotflags
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/infogulch/xtemplate"
 )
 
 func init() {
-	xtemplate.Register("flags", func() xtemplate.DotConfig { return &DotFlagsConfig{} })
+	xtemplate.Register("flags", func() xtemplate.Provider { return &DotFlagsConfig{} })
 }
 
 // DotFlags provides template access to a static key/value map.
@@ -39,8 +39,10 @@ type DotFlagsConfig struct {
 	Values map[string]string `json:"values"`
 }
 
-var _ xtemplate.DotConfig = &DotFlagsConfig{}
+var _ xtemplate.Provider = &DotFlagsConfig{}
 
-func (d *DotFlagsConfig) FieldName() string                      { return d.Name }
-func (d *DotFlagsConfig) Init(_ context.Context) error           { return nil }
-func (d *DotFlagsConfig) Value(_ xtemplate.Request) (any, error) { return DotFlags{d.Values}, nil }
+func (d *DotFlagsConfig) FieldName() string { return d.Name }
+func (d *DotFlagsConfig) Prototype() any    { return DotFlags{} }
+func (d *DotFlagsConfig) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return DotFlags{d.Values}, nil
+}

--- a/providers/dotfs/fs.go
+++ b/providers/dotfs/fs.go
@@ -74,7 +74,7 @@ import (
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 func init() {
-	xtemplate.Register("fs", func() xtemplate.DotConfig { return &DotFsConfig{} })
+	xtemplate.Register("fs", func() xtemplate.Provider { return &DotFsConfig{} })
 }
 
 // WithFs creates an [xtemplate.Option] that can be used with
@@ -118,9 +118,19 @@ type DotFsConfig struct {
 	FS       afero.Fs `json:"-"`
 }
 
-var _ xtemplate.CleanupDotProvider = &DotFsConfig{}
+var (
+	_ xtemplate.Initializer = &DotFsConfig{}
+	_ xtemplate.Finalizer   = &DotFsConfig{}
+)
 
 func (c *DotFsConfig) FieldName() string { return c.Name }
+
+func (p *DotFsConfig) Prototype() any {
+	if p.Writable {
+		return DotFsRW{}
+	}
+	return DotFs{}
+}
 
 func (p *DotFsConfig) Init(ctx context.Context) error {
 	if p.FS == nil {
@@ -181,25 +191,25 @@ func probeWritable(afs afero.Fs, pathHint string) error {
 	return nil
 }
 
-func (p *DotFsConfig) Value(r xtemplate.Request) (any, error) {
+func (p *DotFsConfig) Value(w http.ResponseWriter, r *http.Request) (any, error) {
 	base := DotFs{
 		fs:     p.FS,
-		log:    xtemplate.GetLogger(r.R.Context()),
+		log:    xtemplate.GetLogger(r.Context()),
 		opened: make(map[afero.File]struct{}),
 	}
 	if p.Writable {
 		received := false
 		return DotFsRW{
 			DotFs:    base,
-			w:        r.W,
-			r:        r.R,
+			w:        w,
+			r:        r,
 			received: &received,
 		}, nil
 	}
 	return base, nil
 }
 
-func (p *DotFsConfig) Cleanup(a any, err error) error {
+func (p *DotFsConfig) Finalize(a any, err error) error {
 	var d DotFs
 	switch v := a.(type) {
 	case DotFs:

--- a/providers/dotnats/nats.go
+++ b/providers/dotnats/nats.go
@@ -3,6 +3,7 @@ package dotnats
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/infogulch/xtemplate"
@@ -12,7 +13,7 @@ import (
 )
 
 func init() {
-	xtemplate.Register("nats", func() xtemplate.DotConfig { return &DotNatsConfig{} })
+	xtemplate.Register("nats", func() xtemplate.Provider { return &DotNatsConfig{} })
 }
 
 // WithNats creates an [xtemplate.Option] that adds a nats dot provider to the
@@ -41,11 +42,19 @@ type DotNatsConfig struct {
 
 	server *server.Server
 	js     jetstream.JetStream
+
+	// owned is true when Init created Conn (and possibly the in-process server).
+	// Injected Conn values are not closed.
+	owned bool
 }
 
-var _ xtemplate.DotConfig = &DotNatsConfig{}
+var (
+	_ xtemplate.Initializer = &DotNatsConfig{}
+	_ xtemplate.Closer      = &DotNatsConfig{}
+)
 
 func (d *DotNatsConfig) FieldName() string { return d.Name }
+func (d *DotNatsConfig) Prototype() any    { return &DotNats{} }
 
 func (d *DotNatsConfig) Init(ctx context.Context) error {
 	var err error
@@ -92,12 +101,29 @@ func (d *DotNatsConfig) Init(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to in-process server: %w", err)
 	}
+	d.owned = true
 	d.js, err = jetstream.New(d.Conn, d.JetStreamOptions...)
 	return err
 }
 
-func (d *DotNatsConfig) Value(r xtemplate.Request) (any, error) {
-	return &DotNats{Conn: d.Conn, JetStream: d.js, ctx: r.R.Context()}, nil
+// Close drains/closes a connection opened by Init and shuts down any in-process
+// server. Injected connections are left alone.
+func (d *DotNatsConfig) Close() error {
+	var err error
+	if d.owned && d.Conn != nil {
+		err = d.Conn.Drain()
+		d.Conn = nil
+		d.owned = false
+	}
+	if d.server != nil {
+		d.server.Shutdown()
+		d.server = nil
+	}
+	return err
+}
+
+func (d *DotNatsConfig) Value(_ http.ResponseWriter, r *http.Request) (any, error) {
+	return &DotNats{Conn: d.Conn, JetStream: d.js, ctx: r.Context()}, nil
 }
 
 // DotNats provides template access to a NATS connection.

--- a/providers/dotsmtp/smtp.go
+++ b/providers/dotsmtp/smtp.go
@@ -10,6 +10,7 @@ package dotsmtp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/mail"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func init() {
-	xtemplate.Register("smtp", func() xtemplate.DotConfig { return &DotSMTPConfig{} })
+	xtemplate.Register("smtp", func() xtemplate.Provider { return &DotSMTPConfig{} })
 }
 
 // WithSMTP creates an [xtemplate.Option] that adds an smtp dot provider to the
@@ -74,10 +75,13 @@ type DotSMTPConfig struct {
 	client *gomail.Client
 }
 
-var _ xtemplate.DotConfig = &DotSMTPConfig{}
+var _ xtemplate.Initializer = &DotSMTPConfig{}
 
 // FieldName returns the dot field name contributed by this provider.
 func (d *DotSMTPConfig) FieldName() string { return d.Name }
+
+// Prototype returns the per-request field type.
+func (d *DotSMTPConfig) Prototype() any { return &DotSMTP{} }
 
 // Init applies defaults, validates required fields, and builds the go-mail
 // client. It does not dial; go-mail dials per send.
@@ -178,8 +182,8 @@ func (d *DotSMTPConfig) Init(ctx context.Context) error {
 
 // Value returns the per-request dot value. The returned type carries the
 // request context so a cancelled request aborts the in-flight send.
-func (d *DotSMTPConfig) Value(r xtemplate.Request) (any, error) {
-	return &DotSMTP{cfg: d, ctx: r.R.Context()}, nil
+func (d *DotSMTPConfig) Value(_ http.ResponseWriter, r *http.Request) (any, error) {
+	return &DotSMTP{cfg: d, ctx: r.Context()}, nil
 }
 
 // DotSMTP is the per-request dot value exposed to templates. Call Send to

--- a/providers/dotsql/sql.go
+++ b/providers/dotsql/sql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"net/http"
 	"text/template"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func init() {
-	xtemplate.Register("sql", func() xtemplate.DotConfig { return &DotSqlConfig{} })
+	xtemplate.Register("sql", func() xtemplate.Provider { return &DotSqlConfig{} })
 }
 
 func WithSql(name string, db *sql.DB, opt *sql.TxOptions) xtemplate.Option {
@@ -34,11 +35,20 @@ type DotSqlConfig struct {
 	Driver         string `json:"driver"`
 	Connstr        string `json:"connstr"`
 	MaxOpenConns   int    `json:"max_open_conns"`
+
+	// opened is true when Init opened DB via Driver/Connstr (so Close should
+	// close it). Injected DBs from WithSql are not closed.
+	opened bool
 }
 
-var _ xtemplate.CleanupDotProvider = &DotSqlConfig{}
+var (
+	_ xtemplate.Initializer = &DotSqlConfig{}
+	_ xtemplate.Finalizer   = &DotSqlConfig{}
+	_ xtemplate.Closer      = &DotSqlConfig{}
+)
 
 func (d *DotSqlConfig) FieldName() string { return d.Name }
+func (d *DotSqlConfig) Prototype() any    { return &DotSql{} }
 func (d *DotSqlConfig) Init(ctx context.Context) error {
 	if d.DB != nil {
 		return nil
@@ -49,21 +59,31 @@ func (d *DotSqlConfig) Init(ctx context.Context) error {
 	}
 	db.SetMaxOpenConns(d.MaxOpenConns)
 	if err := db.Ping(); err != nil {
+		_ = db.Close()
 		return fmt.Errorf("failed to ping database on open: %w", err)
 	}
 	d.DB = db
+	d.opened = true
 	return nil
 }
-func (d *DotSqlConfig) Value(r xtemplate.Request) (any, error) {
-	return &DotSql{d.DB, xtemplate.GetLogger(r.R.Context()), r.R.Context(), d.TxOptions, nil}, nil
+func (d *DotSqlConfig) Value(_ http.ResponseWriter, r *http.Request) (any, error) {
+	return &DotSql{d.DB, xtemplate.GetLogger(r.Context()), r.Context(), d.TxOptions, nil}, nil
 }
-func (dp *DotSqlConfig) Cleanup(v any, err error) error {
+func (dp *DotSqlConfig) Finalize(v any, err error) error {
 	d := v.(*DotSql)
 	if err != nil {
 		return errors.Join(err, d.rollback())
-	} else {
-		return errors.Join(err, d.commit())
 	}
+	return errors.Join(err, d.commit())
+}
+func (d *DotSqlConfig) Close() error {
+	if !d.opened || d.DB == nil {
+		return nil
+	}
+	err := d.DB.Close()
+	d.DB = nil
+	d.opened = false
+	return err
 }
 
 // DotSql is used to create a dot field value that can query a SQL database. When

--- a/providers_test.go
+++ b/providers_test.go
@@ -1,24 +1,26 @@
 package xtemplate
 
 import (
-	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 )
 
-// testProvider is a minimal DotConfig used only by the registry tests.
+// testProvider is a minimal Provider shared by package tests (registry, makeDot).
 type testProvider struct {
 	Name string `json:"name"`
 	Val  string `json:"value"`
 }
 
-func (p *testProvider) FieldName() string          { return p.Name }
-func (p *testProvider) Init(context.Context) error { return nil }
-func (p *testProvider) Value(Request) (any, error) { return p.Val, nil }
+func (p *testProvider) FieldName() string { return p.Name }
+func (p *testProvider) Prototype() any    { return "" }
+func (p *testProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return p.Val, nil
+}
 
 func init() {
-	Register("_test", func() DotConfig { return &testProvider{} })
+	Register("_test", func() Provider { return &testProvider{} })
 }
 
 func TestResolveProviders_roundtrip(t *testing.T) {
@@ -69,5 +71,5 @@ func TestRegister_duplicatePanics(t *testing.T) {
 			t.Fatal("expected panic on duplicate registration")
 		}
 	}()
-	Register("_test", func() DotConfig { return &testProvider{} })
+	Register("_test", func() Provider { return &testProvider{} })
 }

--- a/server.go
+++ b/server.go
@@ -149,6 +149,11 @@ func (x *Server) Reload(cfgs ...Option) error {
 		x.cancel()
 	}
 	x.cancel = newcancel
+	if old != nil {
+		if err := old.Close(); err != nil {
+			log.Warn("error closing previous instance providers", slog.Any("error", err))
+		}
+	}
 
 	log.Info("rebuild succeeded", slog.Int64("new_id", new_.id), slog.Duration("rebuild_time", time.Since(start)))
 	return nil
@@ -162,5 +167,10 @@ func (x *Server) Stop() {
 		x.cancel()
 	}
 	x.cancel = nil
-	x.instance.Store(nil)
+	old := x.instance.Swap(nil)
+	if old != nil {
+		if err := old.Close(); err != nil {
+			x.config.Logger.Warn("error closing instance providers on stop", slog.Any("error", err))
+		}
+	}
 }


### PR DESCRIPTION
Rename DotConfig to Provider and split lifecycle into optional capability interfaces (Initializer, Finalizer, Closer) that do not embed Provider. Add Prototype for type inference, pass Value(w, r) only, and close owned resources on instance retire so custom providers share a stable contract.