### PR TITLE
Server lifecycle: Shutdown/retire drain and WithOnClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (so SSE `WaitForServerStop` / Flush helpers observe stop), wait for
   in-flight instance requests up to `ctx`, then close providers. `Stop` is
   immediate teardown (cancelled drain context) on the same path. Addresses #96.
+- `WithOnClose(fn)` registers per-instance cleanup run from `Instance.Close`
+  after provider Closers (reload retire / stop). Per instance, not once per
+  Server—base-config callbacks run on every retire; use `sync.Once` or
+  per-Reload options for one-shot / per-build resources (e.g. temp dirs).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Server.Shutdown(ctx)` for graceful stop: cancel server-owned context first
+  (so SSE `WaitForServerStop` / Flush helpers observe stop), wait for
+  in-flight instance requests up to `ctx`, then close providers. `Stop` is
+  immediate teardown (cancelled drain context) on the same path. Addresses #96.
+
 ### Changed
+
+- **Server lifecycle:** `Server` owns a `serverCtx` (child of `Config.Ctx`).
+  Instance contexts parent on `serverCtx`. Reload retires the old instance by
+  cancelling its context, waiting for in-flight requests (default grace 5s,
+  returns early when idle), then closing providers—without holding the server
+  mutex during the wait. `Serve` watches `serverCtx`, retires the instance, and
+  drains its local `http.Server` (not stored on `Server`). Caddy module
+  `Cleanup` calls `Server.Stop`.
 
 - **Breaking: Change dot provider API**
   - Rename base interface `DotConfig` → `Provider`

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -33,7 +33,7 @@ type XTemplateModule struct {
 
 	FuncsModules []string `json:"funcs_modules,omitempty"`
 
-	handler http.Handler
+	handler *xtemplate.Server
 	cancel  func()
 }
 
@@ -104,8 +104,15 @@ func (m *XTemplateModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ ca
 }
 
 // Cleanup discards resources held by t. Implements caddy.CleanerUpper.
+// Stops the xtemplate Server so instance providers and contexts tear down even
+// though Caddy never calls Serve (handler-only embed).
 func (m *XTemplateModule) Cleanup() error {
-	m.cancel()
+	if m.handler != nil {
+		m.handler.Stop()
+	}
+	if m.cancel != nil {
+		m.cancel()
+	}
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	// the next reload starts from the original config again. Use a single reload
 	// source per server unless you persist options into the base config yourself.
 	Reload <-chan []Option `json:"-" arg:"-"`
+
+	// onClose callbacks for the next Instance built from this config.
+	// See [WithOnClose]. Not JSON. Each Instance takes a reslice at build time.
+	onClose []func() error
 }
 
 // HandlerRoute pairs a ServeMux pattern with an http.Handler.
@@ -182,6 +186,31 @@ func WithHandler(pattern string, h http.Handler) Option {
 func WithProvider(p Provider) Option {
 	return func(c *Config) error {
 		c.Providers = append(c.Providers, p)
+		return nil
+	}
+}
+
+// WithOnClose registers fn to run when the [Instance] built with this option
+// is [Instance.Close]d (reload retire or [Server.Stop]/[Server.Shutdown]).
+// Multiple WithOnClose options append; they run after provider [Closer]s, in
+// reverse registration order. Nil fns are ignored.
+//
+// Callbacks are per instance, not once per Server: if set on the Server base
+// config (e.g. Server(WithOnClose(fn))), fn runs once for every retired
+// instance after each successful Reload and on final stop. That is intentional
+// for hooks like metrics; for one-shot process cleanup wrap with sync.Once.
+// For per-build resources (e.g. a git clone directory), pass WithOnClose only
+// on the Reload options that install that build—not on the base config—so each
+// clone is released with the instance that adopted it.
+//
+// Each Instance stores its own reslice of handlers so Options appends during
+// one build cannot trample another instance's list or the base config slice.
+func WithOnClose(fn func() error) Option {
+	return func(c *Config) error {
+		if fn == nil {
+			return nil
+		}
+		c.onClose = append(c.onClose, fn)
 		return nil
 	}
 }

--- a/instance.go
+++ b/instance.go
@@ -57,6 +57,10 @@ type Instance struct {
 	// providers is the user/core provider list for this instance (not builtins).
 	// Used to call [Closer.Close] when the instance is retired.
 	providers []Provider
+
+	// inflight counts requests that have entered ServeHTTP and not yet returned.
+	// Enter is add-then-check-cancel (no mutex); see waitInFlight.
+	inflight atomic.Int64
 }
 
 // Instance creates a new *Instance from the given config
@@ -305,13 +309,17 @@ func closeProviders(providers []Provider) error {
 var levelDebug2 slog.Level = slog.LevelDebug + 2
 
 func (instance *Instance) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	select {
-	case <-instance.config.Ctx.Done():
+	// Add before checking cancel so waitInFlight cannot observe 0 while a
+	// request is still between "not cancelled" and the increment (WaitGroup
+	// would panic on Add-after-Wait; an atomic counter does not).
+	instance.inflight.Add(1)
+	if instance.config.Ctx.Err() != nil {
+		instance.inflight.Add(-1)
 		instance.config.Logger.Error("received request after xtemplate instance cancelled", slog.String("method", r.Method), slog.String("path", r.URL.Path))
 		http.Error(w, "server stopped", http.StatusInternalServerError)
 		return
-	default:
 	}
+	defer instance.inflight.Add(-1)
 
 	ctx := r.Context()
 	rid := GetRequestId(ctx)
@@ -346,6 +354,31 @@ func (instance *Instance) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			slog.Int64("bytes", metrics.Written),
 			slog.String("pattern", r.Pattern),
 		))
+}
+
+// waitInFlight blocks until inflight is 0 or ctx is done. Caller must cancel
+// the instance context first: concurrent enters then bump the counter, see
+// cancel, and decrement without running the handler. Retire is rare, so a
+// short poll is enough (returns immediately when already idle).
+func (instance *Instance) waitInFlight(ctx context.Context) {
+	if instance == nil {
+		return
+	}
+	if instance.inflight.Load() == 0 {
+		return
+	}
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if instance.inflight.Load() == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 type requestIdType struct{}

--- a/instance.go
+++ b/instance.go
@@ -58,13 +58,16 @@ type Instance struct {
 	// Used to call [Closer.Close] when the instance is retired.
 	providers []Provider
 
+	// onClose from [WithOnClose]; owned reslice for this instance only.
+	onClose []func() error
+
 	// inflight counts requests that have entered ServeHTTP and not yet returned.
 	// Enter is add-then-check-cancel (no mutex); see waitInFlight.
 	inflight atomic.Int64
 }
 
 // Instance creates a new *Instance from the given config
-func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []InstanceRoute, error) {
+func (config *Config) Instance(cfgs ...Option) (inst *Instance, stats *InstanceStats, routes []InstanceRoute, err error) {
 	start := time.Now()
 
 	build := &builder{
@@ -74,8 +77,25 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 		},
 		InstanceStats: &InstanceStats{},
 	}
+	// Reslice so Options append (and other builds) cannot share/trample the
+	// caller's or base config's onClose backing array.
+	build.config.onClose = slices.Clone(build.config.onClose)
 
-	if _, err := build.config.Options(cfgs...); err != nil {
+	defer func() {
+		if err != nil {
+			// Build failed: release any OnClose resources registered for this attempt.
+			if closeErr := runOnClose(build.config.onClose); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
+			return
+		}
+		if inst != nil {
+			inst.onClose = build.config.onClose
+			inst.config.onClose = nil
+		}
+	}()
+
+	if _, err = build.config.Options(cfgs...); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -203,7 +223,6 @@ func (config *Config) Instance(cfgs ...Option) (*Instance, *InstanceStats, []Ins
 		build.providers = dot
 	}
 
-	var err error
 	if build.bufferDot, err = makeDot(slices.Concat([]Provider{dcInstance, dcReq}, dot, []Provider{dcResp})); err != nil {
 		_ = closeProviders(dot)
 		return nil, nil, nil, fmt.Errorf("failed to build buffer dot: %w", err)
@@ -280,16 +299,19 @@ func (x *Instance) Id() int64 {
 	return x.id
 }
 
-// Close releases instance-scoped provider resources ([Closer]).
-// It is safe to call more than once. [Server] calls Close when retiring an
-// instance on reload or stop; callers of [Config.Instance] should call Close
-// when the instance is no longer needed if providers own connections.
+// Close releases instance-scoped provider resources ([Closer]), then runs
+// [WithOnClose] callbacks. It is safe to call more than once. [Server] calls
+// Close when retiring an instance on reload or stop; callers of
+// [Config.Instance] should call Close when the instance is no longer needed if
+// providers own connections or OnClose was used.
 func (x *Instance) Close() error {
 	if x == nil {
 		return nil
 	}
 	err := closeProviders(x.providers)
 	x.providers = nil
+	err = errors.Join(err, runOnClose(x.onClose))
+	x.onClose = nil
 	return err
 }
 
@@ -301,6 +323,20 @@ func closeProviders(providers []Provider) error {
 			if err := c.Close(); err != nil {
 				errs = append(errs, fmt.Errorf("close %s: %w", providers[i].FieldName(), err))
 			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// runOnClose runs callbacks in reverse registration order (destructor-like).
+func runOnClose(fns []func() error) error {
+	var errs []error
+	for i := len(fns) - 1; i >= 0; i-- {
+		if fns[i] == nil {
+			continue
+		}
+		if err := fns[i](); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)

--- a/instance_test.go
+++ b/instance_test.go
@@ -271,9 +271,7 @@ func TestServer_Lifecycle(t *testing.T) {
 		t.Fatalf("server.Instance() = nil after Reload, want non-nil")
 	}
 
-	// After Stop the instance pointer is cleared. Do NOT route a request
-	// through the handler after Stop: Server.Stop currently stores nil and the
-	// handler would panic. Only assert the instance is nil.
+	// After Stop the instance pointer is cleared (new requests get 503).
 	server.Stop()
 	if server.Instance() != nil {
 		t.Errorf("server.Instance() = %v after Stop, want nil", server.Instance())

--- a/onclose_test.go
+++ b/onclose_test.go
@@ -1,0 +1,211 @@
+package xtemplate
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestWithOnClose_RunsOnInstanceClose(t *testing.T) {
+	var calls atomic.Int32
+	fs := newMemFS(t, map[string]string{"index.html": "ok"})
+
+	inst, _, _, err := New().Instance(
+		WithTemplateFS(fs),
+		WithOnClose(func() error {
+			calls.Add(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Instance: %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("OnClose ran before Close: %d", calls.Load())
+	}
+	if err := inst.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("OnClose calls = %d, want 1", calls.Load())
+	}
+	// Idempotent Close
+	if err := inst.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("OnClose calls after second Close = %d, want 1", calls.Load())
+	}
+}
+
+func TestWithOnClose_ReverseOrderAfterProviders(t *testing.T) {
+	var mu sync.Mutex
+	var seq []string
+	add := func(s string) {
+		mu.Lock()
+		seq = append(seq, s)
+		mu.Unlock()
+	}
+
+	fs := newMemFS(t, map[string]string{"index.html": "ok"})
+	inst, _, _, err := New().Instance(
+		WithTemplateFS(fs),
+		WithProvider(&closeOrderProvider{name: "P", onClose: func() { add("provider") }}),
+		WithOnClose(func() error { add("onClose1"); return nil }),
+		WithOnClose(func() error { add("onClose2"); return nil }),
+	)
+	if err != nil {
+		t.Fatalf("Instance: %v", err)
+	}
+	if err := inst.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Providers first, then OnClose in reverse registration order.
+	want := []string{"provider", "onClose2", "onClose1"}
+	mu.Lock()
+	got := append([]string(nil), seq...)
+	mu.Unlock()
+	if len(got) != len(want) {
+		t.Fatalf("seq = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("seq = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestWithOnClose_BaseConfigRunsPerRetiredInstance(t *testing.T) {
+	var calls atomic.Int32
+	fs1 := newMemFS(t, map[string]string{"index.html": "v1"})
+	fs2 := newMemFS(t, map[string]string{"index.html": "v2"})
+
+	srv, err := New().Server(
+		WithTemplateFS(fs1),
+		WithOnClose(func() error {
+			calls.Add(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("OnClose ran before any retire: %d", calls.Load())
+	}
+
+	if err := srv.Reload(WithTemplateFS(fs2)); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("after first Reload OnClose calls = %d, want 1 (old instance)", calls.Load())
+	}
+
+	srv.Stop()
+	if calls.Load() != 2 {
+		t.Fatalf("after Stop OnClose calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestWithOnClose_ResliceDoesNotTrampleBase(t *testing.T) {
+	// Base config has one handler. Building instances that append more OnClose
+	// via Options must not grow or corrupt the base slice.
+	var baseCalls, extraCalls atomic.Int32
+	baseFn := func() error { baseCalls.Add(1); return nil }
+	extraFn := func() error { extraCalls.Add(1); return nil }
+
+	cfg := New()
+	if _, err := cfg.Options(
+		WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})),
+		WithOnClose(baseFn),
+	); err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	if len(cfg.onClose) != 1 {
+		t.Fatalf("base onClose len = %d, want 1", len(cfg.onClose))
+	}
+
+	inst1, _, _, err := cfg.Instance(WithOnClose(extraFn))
+	if err != nil {
+		t.Fatalf("Instance1: %v", err)
+	}
+	if len(cfg.onClose) != 1 {
+		t.Fatalf("base onClose len after Instance1 = %d, want 1 (reslice isolation)", len(cfg.onClose))
+	}
+
+	inst2, _, _, err := cfg.Instance(WithOnClose(extraFn))
+	if err != nil {
+		t.Fatalf("Instance2: %v", err)
+	}
+	if len(cfg.onClose) != 1 {
+		t.Fatalf("base onClose len after Instance2 = %d, want 1", len(cfg.onClose))
+	}
+
+	_ = inst1.Close()
+	_ = inst2.Close()
+	if baseCalls.Load() != 2 {
+		t.Fatalf("base OnClose calls = %d, want 2", baseCalls.Load())
+	}
+	if extraCalls.Load() != 2 {
+		t.Fatalf("extra OnClose calls = %d, want 2", extraCalls.Load())
+	}
+}
+
+func TestWithOnClose_BuildFailureRunsCallbacks(t *testing.T) {
+	var calls atomic.Int32
+	// Missing templates FS path that doesn't exist as dir with no default walk
+	// — use invalid provider-free build: empty TemplatesDir on Os that fails scan
+	// is hard. Force Options success then fail: unsupported precompress encoding.
+	_, _, _, err := New().Instance(
+		WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})),
+		WithOnClose(func() error {
+			calls.Add(1)
+			return nil
+		}),
+		func(c *Config) error {
+			c.Precompress = []string{"not-a-real-encoding"}
+			return nil
+		},
+	)
+	if err == nil {
+		t.Fatal("Instance: want error for bad precompress")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("OnClose on failed build calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestWithOnClose_ErrorJoined(t *testing.T) {
+	fs := newMemFS(t, map[string]string{"index.html": "ok"})
+	inst, _, _, err := New().Instance(
+		WithTemplateFS(fs),
+		WithOnClose(func() error { return errors.New("boom") }),
+	)
+	if err != nil {
+		t.Fatalf("Instance: %v", err)
+	}
+	err = inst.Close()
+	if err == nil || err.Error() == "" {
+		t.Fatalf("Close error = %v, want boom", err)
+	}
+}
+
+// closeOrderProvider is a minimal Closer for ordering tests.
+type closeOrderProvider struct {
+	name    string
+	onClose func()
+}
+
+func (p *closeOrderProvider) FieldName() string { return p.name }
+func (p *closeOrderProvider) Prototype() any    { return struct{}{} }
+func (p *closeOrderProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
+	return struct{}{}, nil
+}
+func (p *closeOrderProvider) Close() error {
+	if p.onClose != nil {
+		p.onClose()
+	}
+	return nil
+}

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package xtemplate
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -10,6 +11,10 @@ import (
 	"time"
 )
 
+// defaultGrace is the bound for draining in-flight work on Serve cancel and
+// on instance retire after Reload. Not a fixed sleep: wait returns early when idle.
+const defaultGrace = 5 * time.Second
+
 // Server is a configured, *reloadable*, xtemplate request handler ready to
 // execute templates and serve static files in response to http requests. It
 // implements [http.Handler] by always routing to the current [Instance].
@@ -17,20 +22,28 @@ import (
 // Call [Server.Reload] to rebuild from the same config (or with options). If
 // successful, Reload atomically swaps the old Instance for the new one so
 // subsequent requests use the new instance; outstanding requests on the old
-// Instance can finish. The old instance's Config.Ctx is cancelled.
+// Instance are given a grace period to finish after the old instance context
+// is cancelled, then providers are closed.
+//
+// Call [Server.Shutdown] for a graceful stop or [Server.Stop] for immediate
+// teardown. When using [Server.Serve], cancelling the server context also
+// drains the local [http.Server] (Serve owns that; Server does not store it).
 //
 // The only way to create a valid *Server is to call [Config.Server].
 type Server struct {
 	instance atomic.Pointer[Instance]
-	cancel   func()
+	cancel   context.CancelFunc // cancels current instance ctx
 
 	mutex  sync.Mutex
 	config Config
+
+	serverCtx    context.Context
+	serverCancel context.CancelFunc
 }
 
 var _ http.Handler = (*Server)(nil)
 
-// Build creates a new Server from an xtemplate.Config.
+// Server creates a new Server from an xtemplate.Config.
 func (config Config) Server(cfgs ...Option) (*Server, error) {
 	if _, err := config.SetDefaults().Options(cfgs...); err != nil {
 		return nil, err
@@ -38,12 +51,17 @@ func (config Config) Server(cfgs ...Option) (*Server, error) {
 
 	config.Logger = config.Logger.WithGroup("xtemplate")
 
+	serverCtx, serverCancel := context.WithCancel(config.Ctx)
+
 	server := &Server{
-		config: config,
+		config:       config,
+		serverCtx:    serverCtx,
+		serverCancel: serverCancel,
 	}
 	err := server.Reload()
 
 	if err != nil {
+		serverCancel()
 		return nil, err
 	}
 
@@ -52,7 +70,7 @@ func (config Config) Server(cfgs ...Option) (*Server, error) {
 			log := config.Logger.WithGroup("reload")
 			for {
 				select {
-				case <-config.Ctx.Done():
+				case <-server.serverCtx.Done():
 					return
 				case opts, ok := <-config.Reload:
 					if !ok {
@@ -70,14 +88,16 @@ func (config Config) Server(cfgs ...Option) (*Server, error) {
 }
 
 // Instance returns the current [Instance]. After calling Reload, previous calls
-// to Instance may be stale.
+// to Instance may be stale. After Stop/Shutdown, returns nil.
 func (x *Server) Instance() *Instance {
 	return x.instance.Load()
 }
 
 // Serve opens a net listener on `listen_addr` and serves requests from it.
-// It returns when the listener fails or when Config.Ctx is cancelled, in which
-// case the server is gracefully shut down and Serve returns nil.
+// It returns when the listener fails or when the server context is cancelled
+// (parent [Config.Ctx] or [Server.Shutdown]/[Server.Stop]), in which case the
+// local [http.Server] is drained (default grace [defaultGrace]), the instance
+// is retired, and Serve returns nil.
 func (x *Server) Serve(listen_addr string) error {
 	ln, err := net.Listen("tcp", listen_addr)
 	if err != nil {
@@ -95,10 +115,17 @@ func (x *Server) Serve(listen_addr string) error {
 		IdleTimeout:       120 * time.Second,
 		// ponytail: no WriteTimeout; it would cap streaming/SSE responses. Add a per-handler deadline if slow writers become a problem.
 	}
+
 	go func() {
-		<-x.config.Ctx.Done()
-		_ = srv.Shutdown(context.Background())
+		<-x.serverCtx.Done()
+		drainCtx, cancel := context.WithTimeout(context.Background(), defaultGrace)
+		defer cancel()
+		// Retire instance first (serverCtx already cancelled → SSE unblocks),
+		// then drain this Serve-local http.Server. Server does not own *http.Server.
+		_ = x.Shutdown(drainCtx)
+		_ = srv.Shutdown(drainCtx)
 	}()
+
 	if err := srv.Serve(ln); err != http.ErrServerClosed {
 		return err
 	}
@@ -117,12 +144,18 @@ func (x *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Reload creates a new Instance from the config and swaps it with the
-// current instance if successful, otherwise returns the error.
+// current instance if successful, otherwise returns the error. The previous
+// instance context is cancelled, in-flight requests are waited on up to
+// [defaultGrace], then providers are closed.
 func (x *Server) Reload(cfgs ...Option) error {
 	start := time.Now()
 
 	x.mutex.Lock()
-	defer x.mutex.Unlock()
+
+	if err := x.serverCtx.Err(); err != nil {
+		x.mutex.Unlock()
+		return errors.New("server stopped")
+	}
 
 	log := x.config.Logger.WithGroup("reload")
 	old := x.instance.Load()
@@ -130,47 +163,95 @@ func (x *Server) Reload(cfgs ...Option) error {
 		log = log.With(slog.Int64("old_id", old.id))
 	}
 
-	var newcancel func()
+	var newcancel context.CancelFunc
 	var new_ *Instance
 	{
 		var err error
 		config := x.config
-		config.Ctx, newcancel = context.WithCancel(x.config.Ctx)
+		config.Ctx, newcancel = context.WithCancel(x.serverCtx)
 		new_, _, _, err = config.Instance(cfgs...)
 		if err != nil {
 			newcancel()
+			x.mutex.Unlock()
 			log.Info("failed to load", slog.Any("error", err), slog.Duration("rebuild_time", time.Since(start)))
 			return err
 		}
 	}
 
-	x.instance.CompareAndSwap(old, new_)
-	if x.cancel != nil {
-		x.cancel()
-	}
+	old = x.instance.Swap(new_)
+	oldCancel := x.cancel
 	x.cancel = newcancel
+	x.mutex.Unlock()
+
 	if old != nil {
-		if err := old.Close(); err != nil {
-			log.Warn("error closing previous instance providers", slog.Any("error", err))
-		}
+		graceCtx, graceCancel := context.WithTimeout(context.Background(), defaultGrace)
+		x.retire(old, oldCancel, graceCtx)
+		graceCancel()
 	}
 
 	log.Info("rebuild succeeded", slog.Int64("new_id", new_.id), slog.Duration("rebuild_time", time.Since(start)))
 	return nil
 }
 
-func (x *Server) Stop() {
-	x.mutex.Lock()
-	defer x.mutex.Unlock()
-
-	if x.cancel != nil {
-		x.cancel()
+// Shutdown stops the server gracefully.
+//
+//  1. Nils the current instance (new requests get 503) and cancels serverCtx
+//     (cascades into the instance context so SSE/Flush observe stop).
+//  2. Waits for in-flight instance requests up to ctx, then Closes providers.
+//
+// When [Server.Serve] is running, cancelling serverCtx also causes Serve to
+// drain its local [http.Server]; Shutdown itself does not own or call into it.
+//
+// ctx bounds only the in-flight wait; teardown always runs. Safe if Serve never
+// ran (handler-only / Caddy). Idempotent.
+func (x *Server) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	x.cancel = nil
+
+	x.mutex.Lock()
 	old := x.instance.Swap(nil)
+	oldCancel := x.cancel
+	x.cancel = nil
+
+	if x.serverCancel != nil {
+		x.serverCancel()
+	}
+	x.mutex.Unlock()
+
+	// Cancel instance explicitly as well (no-op if already cancelled via serverCtx).
+	if oldCancel != nil {
+		oldCancel()
+	}
+
 	if old != nil {
+		old.waitInFlight(ctx)
 		if err := old.Close(); err != nil {
-			x.config.Logger.Warn("error closing instance providers on stop", slog.Any("error", err))
+			x.config.Logger.Warn("error closing instance providers on shutdown", slog.Any("error", err))
 		}
+	}
+
+	return nil
+}
+
+// Stop is immediate teardown: no drain wait, then the same path as [Shutdown].
+func (x *Server) Stop() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = x.Shutdown(ctx)
+}
+
+// retire cancels an instance, waits for in-flight requests (or grace), then Closes.
+// Must not be called under x.mutex (wait can take up to grace).
+func (x *Server) retire(old *Instance, oldCancel context.CancelFunc, graceCtx context.Context) {
+	if old == nil {
+		return
+	}
+	if oldCancel != nil {
+		oldCancel()
+	}
+	old.waitInFlight(graceCtx)
+	if err := old.Close(); err != nil {
+		x.config.Logger.Warn("error closing previous instance providers", slog.Any("error", err))
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,10 @@ package xtemplate
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -34,4 +38,246 @@ func TestServe_ReturnsOnCtxCancel(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Serve did not return after Ctx cancel")
 	}
+
+	if srv.Instance() != nil {
+		t.Error("Instance() non-nil after Serve returned on cancel, want nil")
+	}
 }
+
+func TestShutdown_IdempotentAnd503(t *testing.T) {
+	cfg := New()
+	srv, err := cfg.Server(WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+	srv.Stop() // also idempotent with Shutdown
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestStop_CancelsInstanceCtxWithoutParentCancel(t *testing.T) {
+	// Embedder leaves Config.Ctx live; Stop must still cancel instance work.
+	cfg := New()
+	srv, err := cfg.Server(WithTemplateFS(newMemFS(t, map[string]string{
+		"index.html": "ok",
+		// Initial Flush signals the test that WaitForServerStop is about to block.
+		"sse.html": `{{define "SSE /wait"}}{{.Flush.Flush}}{{.Flush.WaitForServerStop}}data: bye{{printf "\n\n"}}{{end}}`,
+	})))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+
+	// Parent Config.Ctx must still be live after Stop for this test's point.
+	select {
+	case <-cfg.Ctx.Done():
+		t.Fatal("Config.Ctx should still be live before Stop")
+	default:
+	}
+
+	body := runSSEUntilStop(t, srv.Instance(), "/wait", func() {
+		select {
+		case <-cfg.Ctx.Done():
+			t.Error("Config.Ctx was cancelled; Stop should not require parent cancel")
+		default:
+		}
+		srv.Stop()
+	})
+	if !strings.Contains(body, "data: bye") {
+		t.Fatalf("body = %q, want final data: bye after WaitForServerStop", body)
+	}
+
+	select {
+	case <-cfg.Ctx.Done():
+		t.Error("Config.Ctx should remain live after Stop")
+	default:
+	}
+}
+
+func TestReload_RetiresOldInstanceEarlyWhenIdle(t *testing.T) {
+	cfg := New()
+	srv, err := cfg.Server(WithTemplateFS(newMemFS(t, map[string]string{"index.html": "V1"})))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	defer srv.Stop()
+
+	start := time.Now()
+	if err := srv.Reload(WithTemplateFS(newMemFS(t, map[string]string{"index.html": "V2"}))); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	elapsed := time.Since(start)
+	// Grace is 5s; idle retire must not burn most of it.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("idle Reload retire took %v, want << defaultGrace", elapsed)
+	}
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if !strings.Contains(w.Body.String(), "V2") {
+		t.Fatalf("body = %q, want V2", w.Body.String())
+	}
+}
+
+func TestReload_AllowsInFlightSSEFinalWrite(t *testing.T) {
+	fs := func(marker string) map[string]string {
+		return map[string]string{
+			"index.html": marker,
+			"sse.html":   `{{define "SSE /wait"}}{{.Flush.Flush}}{{.Flush.WaitForServerStop}}data: done{{printf "\n\n"}}{{end}}`,
+		}
+	}
+	srv, err := New().Server(WithTemplateFS(newMemFS(t, fs("before"))))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	defer srv.Stop()
+
+	body := runSSEUntilStop(t, srv.Instance(), "/wait", func() {
+		if err := srv.Reload(WithTemplateFS(newMemFS(t, fs("after")))); err != nil {
+			t.Errorf("Reload: %v", err)
+		}
+	})
+	if !strings.Contains(body, "data: done") {
+		t.Fatalf("old SSE body = %q, want final event after instance cancel", body)
+	}
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if !strings.Contains(w.Body.String(), "after") {
+		t.Fatalf("new instance body = %q, want after", w.Body.String())
+	}
+}
+
+func TestShutdown_DrainsInFlightHandler(t *testing.T) {
+	srv, err := New().Server(WithTemplateFS(newMemFS(t, map[string]string{
+		"index.html": "ok",
+		"sse.html":   `{{define "SSE /wait"}}{{.Flush.Flush}}{{.Flush.WaitForServerStop}}data: drained{{printf "\n\n"}}{{end}}`,
+	})))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+
+	body := runSSEUntilStop(t, srv.Instance(), "/wait", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	})
+	if !strings.Contains(body, "data: drained") {
+		t.Fatalf("body = %q, want drained final event", body)
+	}
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestReload_AfterStopFails(t *testing.T) {
+	srv, err := New().Server(WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})))
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	srv.Stop()
+	if err := srv.Reload(); err == nil {
+		t.Fatal("Reload after Stop: want error")
+	}
+}
+
+// runSSEUntilStop starts an SSE request on inst that blocks in WaitForServerStop
+// (template must Flush first so we can observe start), then runs stopFn and
+// returns the response body.
+func runSSEUntilStop(t *testing.T, inst *Instance, path string, stopFn func()) string {
+	t.Helper()
+	if inst == nil {
+		t.Fatal("instance is nil")
+	}
+
+	started := make(chan struct{})
+	done := make(chan string, 1)
+	go func() {
+		w := &blockingSSERecorder{started: started}
+		r := httptest.NewRequest(http.MethodGet, path, nil)
+		r.Header.Set("Accept", "text/event-stream")
+		inst.ServeHTTP(w, r)
+		done <- w.Body.String()
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not start")
+	}
+
+	// Let the template reach WaitForServerStop after the initial Flush.
+	time.Sleep(20 * time.Millisecond)
+	stopFn()
+
+	select {
+	case body := <-done:
+		return body
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not finish after stop")
+		return ""
+	}
+}
+
+// blockingSSERecorder implements http.ResponseWriter and http.Flusher and
+// signals when the first write or flush occurs.
+type blockingSSERecorder struct {
+	HeaderMap http.Header
+	Body      strings.Builder
+	Code      int
+	started   chan struct{}
+	once      sync.Once
+}
+
+func (w *blockingSSERecorder) Header() http.Header {
+	if w.HeaderMap == nil {
+		w.HeaderMap = make(http.Header)
+	}
+	return w.HeaderMap
+}
+
+func (w *blockingSSERecorder) Write(b []byte) (int, error) {
+	w.signalStarted()
+	if w.Code == 0 {
+		w.Code = http.StatusOK
+	}
+	return w.Body.Write(b)
+}
+
+func (w *blockingSSERecorder) WriteHeader(statusCode int) {
+	w.Code = statusCode
+}
+
+func (w *blockingSSERecorder) Flush() {
+	w.signalStarted()
+}
+
+func (w *blockingSSERecorder) signalStarted() {
+	w.once.Do(func() {
+		if w.started != nil {
+			close(w.started)
+		}
+	})
+}
+
+var (
+	_ http.ResponseWriter = (*blockingSSERecorder)(nil)
+	_ http.Flusher        = (*blockingSSERecorder)(nil)
+)


### PR DESCRIPTION
## Summary

Server-owned lifetime and per-instance cleanup, as groundwork for template sources and graceful reload/stop (#96).

### Server lifecycle
- Own a `serverCtx` (child of `Config.Ctx`); instance contexts parent on it
- `Shutdown(ctx)` / `Stop`: nil instance (503), cancel `serverCtx`, wait in-flight up to `ctx`, then `Close` providers
- Reload retires the old instance outside the mutex: cancel → wait (default 5s grace, returns early when idle) → `Close`
- In-flight tracking via atomic counter (add-then-check-cancel; no hot-path mutex)
- `Serve` watches `serverCtx`, runs `Shutdown`, then drains its **local** `http.Server` (not stored on `Server`)
- Caddy `Cleanup` calls `Server.Stop`
- Fixes #96 (reload/shutdown timeouts for buffered & SSE)

### WithOnClose
- `WithOnClose(fn)` registers per-instance callbacks run from `Instance.Close` **after** provider `Closer`s (reverse registration order)
- Each build **reslices** handlers so Options appends cannot trample the base config or other instances
- Failed builds run callbacks so orphan resources (e.g. temp dirs) still release
- Semantics are **per instance**, not once per Server: base-config callbacks run on every retire; use `sync.Once` or per-Reload options for one-shot / per-build cleanup (e.g. future git clones)

## Test plan
- [x] Package tests for lifecycle (Serve cancel, Shutdown/Stop, reload SSE final write, idle early retire)
- [x] Package tests for `WithOnClose` (close, order, base multi-retire, reslice isolation, failed build, errors)
- [x] `go test ./...`