### PR TITLE
Fix reload lifecycle and HTTP response edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking: sticky Go providers are factories**
+  - `Config.Providers` is `[]ProviderFactory` (`func() Provider`);
+    `WithProvider` takes a factory, not a live value
+  - Each Instance / Reload materializes fresh providers (parity with JSON
+    `providers` decode). Package helpers (`WithBus`, `WithSql`, …) wrap
+    `WithProvider`
+  - `dotsmtp.WithSMTP` takes `DotSMTPConfig` by value (frozen at option
+    construction; each build clears runtime client state)
 - **Breaking: template Config surface**
   - Drop public `TemplatesDir` & `Config.Reload`
   - Use `Controller` / `WithController` / `WithTemplateFS` / `WithTemplateDir`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Duration` type that allows for human-readable duration parsing and formatting
   in config files.
 
+### Fixed
+
+- Bus: instance cancel `Kick`s subscribers (closes ranges for SSE) without
+  rejecting further Publish; full `Shutdown` only in provider `Close` after
+  drain.
+- NATS: destroy in-process server only in `Close` after Conn drain (not on
+  cancel); clean up partial Init failures; `Subscribe` teardown is race-safe.
+
 ### Changed
 
 - **Breaking: template Config surface**

--- a/app/README.md
+++ b/app/README.md
@@ -31,7 +31,7 @@ import (
 func main() {
 	xtemplate.DefaultControllerType = "watchfs"
 	app.Main(
-		// xtemplate.WithProvider(...),
+		// xtemplate.WithProvider(func() xtemplate.Provider { return myProvider{} }),
 		// xtemplate.WithFuncMaps(...),
 	)
 }

--- a/config.go
+++ b/config.go
@@ -47,7 +47,9 @@ type Config struct {
 	CrossOrigin CrossOriginConfig `json:"crossorigin" arg:"-"`
 
 	ProvidersRaw []json.RawMessage `json:"providers,omitempty" arg:"-"`
-	Providers    []Provider        `json:"-" arg:"-"`
+	// Providers holds factories that produce a fresh [Provider] per Instance
+	// build / Reload (same isolation as JSON ProvidersRaw → resolveProviders).
+	Providers []ProviderFactory `json:"-" arg:"-"`
 
 	// Encodings to pre-compress static files into at load time. Supported values:
 	// "gzip", "zstd", "br". Default empty (no pre-compression).
@@ -128,7 +130,8 @@ func (config *Config) SetDefaults() *Config {
 
 // cloneSlices replaces every append-owned slice with a copy so later Options
 // or builds cannot mutate the caller's (or sticky Server's) backing arrays.
-// Maps inside FuncMaps are cloned; Provider values and Handler refs are not deep-copied.
+// Maps inside FuncMaps are cloned; ProviderFactory funcs and Handler refs are
+// not deep-copied (factories are invoked per build to produce fresh Providers).
 func (c *Config) cloneSlices() {
 	c.ControllerRaw = slices.Clone(c.ControllerRaw)
 	if c.ProvidersRaw != nil {
@@ -272,9 +275,14 @@ func WithHandler(pattern string, h http.Handler) Option {
 	}
 }
 
-func WithProvider(p Provider) Option {
+// WithProvider appends a factory that produces a provider on each Instance
+// build. The factory must not return nil. Rejects a nil factory.
+func WithProvider(f ProviderFactory) Option {
 	return func(c *Config) error {
-		c.Providers = append(c.Providers, p)
+		if f == nil {
+			return fmt.Errorf("nil provider factory")
+		}
+		c.Providers = append(c.Providers, f)
 		return nil
 	}
 }

--- a/docs/how-to/create-a-provider.md
+++ b/docs/how-to/create-a-provider.md
@@ -33,7 +33,7 @@ func (shopProvider) Prototype() any                            { return Shop{} }
 func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) { return Shop{}, nil }
 ```
 
-- `FieldName` chooses the dot field on the dot context. Two providers on one instance must not share a field name.
+- `FieldName` chooses the dot field on the dot context. It must be a unique, non-empty, exported, valid Go identifier (e.g. `Shop`, not `shop` or `""` or `1Shop` or `Shop-Data`).
 - `Prototype` must return a non-nil value of the same concrete type that `Value` returns. It is discarded after type inference.
 - Methods on the value returned by `Value` are callable from templates (`{{.Shop.Product 1}}`).
 

--- a/docs/how-to/create-a-provider.md
+++ b/docs/how-to/create-a-provider.md
@@ -8,7 +8,7 @@ A complete runnable example: [`examples/dotprovider`](../../examples/dotprovider
 
 Every path implements the same `Provider` interface. Pick by how the provider is configured:
 
-- **Custom provider** - construct it in Go and pass `WithProvider` (or put it on `Config.Providers`). Best for app-specific code next to `main`. Not selectable from JSON or Caddyfile.
+- **Custom provider** - implement `Provider` and pass a **factory** via `WithProvider` (or append to `Config.Providers`). Best for app-specific code next to `main`. Not selectable from JSON or Caddyfile.
 - **Provider package** - self-register a type from `init()` so JSON can decode `"type"`. Required when the binary must resolve providers from config (CLI or Caddy JSON).
 - **Caddyfile provider** - a Caddy module under `xtemplate.providers.*` that parses `provider <type> <field> { }` into JSON.
 
@@ -37,7 +37,7 @@ func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) { ret
 - `Prototype` must return a non-nil value of the same concrete type that `Value` returns. It is discarded after type inference.
 - Methods on the value returned by `Value` are callable from templates (`{{.Shop.Product 1}}`).
 
-Optional: implement `Initializer` for instance-scoped setup (open connections, validate config). The instance context is cancelled on reload/stop; retain it on the provider if request-time code must observe reload/stop (do not expect it on `Value`).
+Optional: implement `Initializer` for instance-scoped setup (open connections, validate config). The instance context is cancelled on reload/stop; retain it on the provider if request-time code must observe reload/stop (do not expect it on `Value`). Prefer cooperative stop on cancel; destroy owned resources in `Closer.Close` after drain when possible.
 
 ```go
 type Initializer interface {
@@ -63,17 +63,19 @@ type Closer interface {
 
 ## 2a. Custom provider: `WithProvider`
 
-A custom provider is user Go code attached to the config without appearing in the type registry:
+A custom provider is user Go code attached to the config without appearing in the type registry. `WithProvider` takes a **factory** (`func() Provider`) so each Instance / Reload build gets a fresh provider value (same isolation as JSON `providers` decoding). Do not stick a single live `Provider` pointer across reloads.
 
 ```go
-app.Main(xtemplate.WithProvider(shopProvider{}))
+app.Main(xtemplate.WithProvider(func() xtemplate.Provider {
+	return shopProvider{}
+}))
 // or: cfg.Options(xtemplate.WithProvider(...)); cfg.Server() / cfg.Instance()
-// or append to Config.Providers
+// or append factories to Config.Providers
 ```
 
-On instance load, xtemplate builds the dot context struct to include your field. On every request, `Value` runs before the template executes.
+On instance load, xtemplate invokes each factory, builds the dot context struct to include your field, and runs optional `Init`. On every request, `Value` runs before the template executes.
 
-No JSON `"type"` is involved: the provider is already a constructed `Provider` value.
+No JSON `"type"` is involved: the factory produces a `Provider` directly.
 
 ## 2b. Provider package: xtemplate registry (`providers.go`)
 
@@ -171,7 +173,9 @@ func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
 }
 
 func main() {
-	app.Main(xtemplate.WithProvider(shopProvider{}))
+	app.Main(xtemplate.WithProvider(func() xtemplate.Provider {
+		return shopProvider{}
+	}))
 }
 ```
 

--- a/docs/how-to/custom-build.md
+++ b/docs/how-to/custom-build.md
@@ -54,7 +54,7 @@ Pass overrides:
 ```go
 app.Main(
 	xtemplate.WithFuncMaps(myFuncs),
-	xtemplate.WithProvider(...),
+	xtemplate.WithProvider(func() xtemplate.Provider { return myProvider{} }),
 )
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,7 +33,7 @@ App-only (not on `xtemplate.Config` itself):
 | `listen` | `-l` / `--listen` | `0.0.0.0:8080` | HTTP listen address |
 | `log_level` | `--loglevel` | `-2` | slog level |
 
-Go-only options (not in JSON): `Controller`, `FuncMaps`, `Handlers`, `Ctx`, `Logger`, and providers via `WithProvider`. Dual-write: `WithTemplateFS`, `WithTemplateDir`.
+Go-only options (not in JSON): `Controller`, `FuncMaps`, `Handlers`, `Ctx`, `Logger`, and providers via `WithProvider` factories (or package helpers like `dotbus.WithBus`). Dual-write: `WithTemplateFS`, `WithTemplateDir`.
 
 ### Controller types
 

--- a/docs/reference/dot-context.md
+++ b/docs/reference/dot-context.md
@@ -145,4 +145,4 @@ Typical field name: `.Email`. Config requires `host` and `from` (default sender)
 
 ## Custom providers
 
-Implement `xtemplate.Provider` and attach with `WithProvider` (or register a provider type for JSON/Caddyfile). See [How to create a custom dot provider](../how-to/create-a-provider.md) and [`examples/dotprovider`](../../examples/dotprovider/).
+Implement `xtemplate.Provider` and attach with a `WithProvider` factory (or register a provider type for JSON/Caddyfile). See [How to create a custom dot provider](../how-to/create-a-provider.md) and [`examples/dotprovider`](../../examples/dotprovider/).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -58,8 +58,8 @@ Domain terms for xtemplate. Behavior and APIs live in the rest of the [docs](../
 
 **Provider package**: Go package that self-registers a provider type in `init()`.
 
-**Custom provider**: User Go code via `Config.Providers` / `WithProvider`, not via the type registry.
+**Custom provider**: User Go code attached via `Config.Providers` / `WithProvider` as a factory (`func() Provider`), not via the type registry. Factories run on each Instance / Reload so Init/Close stay per-instance.
 
-**Provider config**: Type, field name, and type-specific settings (JSON via the registry, or a constructed `Provider`).
+**Provider config**: Type, field name, and type-specific settings (JSON via the registry, or produced by a factory / package helper).
 
 **Caddyfile provider**: Caddy module `xtemplate.providers.*` that parses `provider <type> <field> { }` into config JSON.

--- a/docs/reference/instance-loading.md
+++ b/docs/reference/instance-loading.md
@@ -11,7 +11,7 @@ While an instance is loading, xtemplate walks the private build-root FS. For Ser
 - Files matching `Config.TemplateExtension` (default `.html`) are parsed into the instance's template namespace: each becomes a path template (and may define additional define templates).
 - All other files are static files (served as-is), except compressed siblings of static files (`.gz`, `.zst`, `.br`) which become alternate encodings of the identity file.
 - Hidden **directories** (names starting with `.`, e.g. `.git`) are skipped when walking, so their contents are not loaded.
-- Hidden **file basenames** (e.g. `.env`, `.htaccess`) under a normal directory are still loaded: non-templates become static routes; path templates are parsed into the global namespace (so you can `{{template "/shared/.head.html" .}}`) but are not given a file-based GET route.
+- Hidden **file basenames** (e.g. `.env`, `.htaccess`) under a normal directory: non-templates are **not** registered as static routes (so secrets like `.env` are not public). Path templates with hidden basenames are still parsed into the global namespace (so you can `{{template "/shared/.head.html" .}}`) but are not given a file-based GET route. Never place secrets under the template root.
 
 ## Path templates (from disk)
 

--- a/dot.go
+++ b/dot.go
@@ -3,6 +3,7 @@ package xtemplate
 import (
 	"context"
 	"fmt"
+	"go/token"
 	"net/http"
 	"reflect"
 	"sync"
@@ -59,17 +60,37 @@ type Closer interface {
 	Close() error
 }
 
+// validateProviderFieldName checks that name is a non-empty exported Go
+// identifier suitable for reflect.StructOf. Invalid names panic inside
+// StructOf; callers should return a config error instead.
+func validateProviderFieldName(name string) error {
+	if name == "" {
+		return fmt.Errorf("provider field name is empty")
+	}
+	if !token.IsIdentifier(name) {
+		return fmt.Errorf("provider field name %q is not a valid Go identifier", name)
+	}
+	if !token.IsExported(name) {
+		return fmt.Errorf("provider field name %q must be exported (start with an uppercase letter)", name)
+	}
+	return nil
+}
+
 func makeDot(dps []Provider) (dot, error) {
 	fields := make([]reflect.StructField, 0, len(dps))
 	finalizers := []finalizer{}
 	for i, dp := range dps {
+		name := dp.FieldName()
+		if err := validateProviderFieldName(name); err != nil {
+			return dot{}, fmt.Errorf("dot provider %T: %w", dp, err)
+		}
 		a := dp.Prototype()
 		t := reflect.TypeOf(a)
 		if t == nil {
-			return dot{}, fmt.Errorf("dot provider %q (%T) Prototype returned nil; Prototype must return a non-nil typed value", dp.FieldName(), dp)
+			return dot{}, fmt.Errorf("dot provider %q (%T) Prototype returned nil; Prototype must return a non-nil typed value", name, dp)
 		}
 		f := reflect.StructField{
-			Name:      dp.FieldName(),
+			Name:      name,
 			Type:      t,
 			Anonymous: false, // alas
 		}

--- a/dot_flush_test.go
+++ b/dot_flush_test.go
@@ -271,6 +271,27 @@ func TestServeHTTP_SSE_RequiresEventStreamAccept(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_SSE_ErrorAfterStreamDoesNotWrite500 ensures cleanup does not
+// call http.Error after the SSE stream has started (would corrupt the body).
+func TestServeHTTP_SSE_ErrorAfterStreamDoesNotWrite500(t *testing.T) {
+	inst := buildInstance(t, map[string]string{
+		"feed.html": `{{define "SSE /events"}}data: hi{{printf "\n\n"}}{{$.Flush.Flush}}{{failf "boom"}}{{end}}`,
+	})
+
+	fr := newFlushRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/events", nil)
+	r.Header.Set("Accept", "text/event-stream")
+	inst.ServeHTTP(fr, r)
+
+	body := fr.Body.String()
+	if !strings.Contains(body, "data: hi") {
+		t.Errorf("body = %q, want streamed event", body)
+	}
+	if strings.Contains(strings.ToLower(body), "internal server error") {
+		t.Errorf("body = %q must not contain http.Error 500 text after stream start", body)
+	}
+}
+
 func TestServeHTTP_SSE_FlushesIncrementally(t *testing.T) {
 	inst := buildInstance(t, map[string]string{
 		"feed.html": `{{define "SSE /events"}}{{range .Flush.Repeat 2}}data: {{.}}{{printf "\n\n"}}{{$.Flush.Flush}}{{$.Flush.Sleep 5}}{{end}}{{end}}`,

--- a/dot_resp.go
+++ b/dot_resp.go
@@ -1,7 +1,9 @@
 package xtemplate
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"maps"
@@ -10,6 +12,11 @@ import (
 	"strings"
 	"time"
 )
+
+// errResponseServed is returned from [dotRespProvider.Finalize] when
+// [DotResp.ServeContent] already wrote the full response. Buffered handlers
+// treat it as success and must not write the template buffer or call http.Error.
+var errResponseServed = errors.New("response already served")
 
 type dotRespProvider struct{}
 
@@ -31,12 +38,13 @@ func (dotRespProvider) Finalize(v any, err error) error {
 	if d.served {
 		// The response was already fully written by ServeContent (which calls
 		// WriteHeader itself); writing headers or status again here would cause
-		// a superfluous WriteHeader call.
-		return err
+		// a superfluous WriteHeader call. Signal the handler to skip the buffer.
+		return errResponseServed
 	}
 	var errSt ErrorStatus
 	if errors.As(err, &errSt) {
-		// headers?
+		// Apply intended client status; handler must not overwrite with 500.
+		maps.Copy(d.w.Header(), d.Header)
 		d.w.WriteHeader(int(errSt))
 	} else if err == nil {
 		maps.Copy(d.w.Header(), d.Header)
@@ -59,14 +67,20 @@ type DotResp struct {
 
 // ServeContent aborts execution of the template and instead responds to the
 // request with content with any headers set by AddHeader and SetHeader so far
-// but ignoring SetStatus.
+// but ignoring SetStatus. content must be a string, []byte, or io.ReadSeeker.
 func (d *DotResp) ServeContent(path_ string, modtime time.Time, content any) (string, error) {
 	var reader io.ReadSeeker
 	switch c := content.(type) {
+	case nil:
+		return "", fmt.Errorf("ServeContent: content is nil")
 	case string:
 		reader = strings.NewReader(c)
+	case []byte:
+		reader = bytes.NewReader(c)
 	case io.ReadSeeker:
 		reader = c
+	default:
+		return "", fmt.Errorf("ServeContent: unsupported content type %T (want string, []byte, or io.ReadSeeker)", content)
 	}
 	path_ = path.Clean(path_)
 	d.log.Debug("serving content response", slog.String("path", path_))

--- a/dot_resp_test.go
+++ b/dot_resp_test.go
@@ -1,10 +1,12 @@
 package xtemplate
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // countingResponseWriter wraps an httptest.ResponseRecorder and counts how many
@@ -48,5 +50,92 @@ func TestDotResp_ServeContent_NoSuperfluousWriteHeader(t *testing.T) {
 	}
 	if body := cw.rec.Body.String(); !strings.Contains(body, "hello world") {
 		t.Errorf("body = %q, want it to contain %q", body, "hello world")
+	}
+}
+
+// TestDotResp_ServeContent_NoTrailingBuffer ensures the buffered handler does
+// not append template buffer bytes after ServeContent has written the body.
+func TestDotResp_ServeContent_NoTrailingBuffer(t *testing.T) {
+	inst := buildInstance(t, map[string]string{
+		// Content before ServeContent would previously be written after the
+		// ServeContent body, corrupting Content-Length / response.
+		"serve.html": `BEFORE{{.Resp.ServeContent "test.txt" now "hello world"}}AFTER`,
+	})
+
+	w := doRequest(inst, http.MethodGet, "/serve")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	if body != "hello world" {
+		t.Errorf("body = %q, want exactly %q (no BEFORE/AFTER buffer)", body, "hello world")
+	}
+}
+
+func TestDotResp_ServeContent_Bytes(t *testing.T) {
+	// Drive via provider that calls ServeContent with []byte — template string
+	// path is covered above; unit-test the type switch for []byte / bad types.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	d := DotResp{
+		Header: make(http.Header),
+		status: http.StatusOK,
+		w:      w,
+		r:      r,
+		log:    GetLogger(r.Context()),
+	}
+	if _, err := d.ServeContent("b.bin", time.Time{}, []byte("bytes-ok")); err == nil {
+		// ServeContent returns ReturnError on success
+		t.Fatal("expected ReturnError")
+	} else if _, ok := err.(ReturnError); !ok {
+		t.Fatalf("err = %v, want ReturnError", err)
+	}
+	if !strings.Contains(w.Body.String(), "bytes-ok") {
+		t.Errorf("body = %q, want bytes-ok", w.Body.String())
+	}
+}
+
+func TestDotResp_ServeContent_UnsupportedType(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	d := DotResp{
+		Header: make(http.Header),
+		status: http.StatusOK,
+		w:      w,
+		r:      r,
+		log:    GetLogger(r.Context()),
+	}
+	_, err := d.ServeContent("x", time.Time{}, 123)
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+	if !strings.Contains(err.Error(), "unsupported content type") {
+		t.Errorf("err = %v, want unsupported content type", err)
+	}
+	_, err = d.ServeContent("x", time.Time{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Errorf("nil content err = %v, want nil message", err)
+	}
+}
+
+// TestErrorStatus_PreservesClientStatus ensures cleanup does not replace an
+// intentional ErrorStatus (e.g. 400 from uploads) with http.Error(500).
+func TestErrorStatus_PreservesClientStatus(t *testing.T) {
+	inst := buildInstance(t, map[string]string{
+		"bad.html": `{{errorstatus 400}}`,
+	}, WithFuncMaps(map[string]any{
+		// Last return must be error for template execution to abort.
+		"errorstatus": func(code int) (string, error) {
+			return "", fmt.Errorf("client: %w", ErrorStatus(code))
+		},
+	}))
+
+	w := doRequest(inst, http.MethodGet, "/bad")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body %q)", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	// Must not be the generic 500 body from http.Error.
+	if strings.Contains(strings.ToLower(w.Body.String()), "internal server error") {
+		t.Errorf("body = %q, must not be internal server error", w.Body.String())
 	}
 }

--- a/dot_test.go
+++ b/dot_test.go
@@ -46,7 +46,7 @@ func TestMakeDot_RejectsInvalidFieldNames(t *testing.T) {
 func TestInstance_RejectsInvalidProviderFieldName(t *testing.T) {
 	cfg, err := New().Options(
 		WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})),
-		WithProvider(&testProvider{Name: "db", Val: "x"}),
+		WithProvider(func() Provider { return &testProvider{Name: "db", Val: "x"} }),
 	)
 	if err != nil {
 		t.Fatalf("Options: %v", err)

--- a/dot_test.go
+++ b/dot_test.go
@@ -5,8 +5,60 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestValidateProviderFieldName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"Bus", false},
+		{"DB", false},
+		{"X1", false},
+		{"", true},
+		{"db", true},       // not exported
+		{"1Bus", true},     // not an identifier
+		{"Bus-Name", true}, // invalid character
+		{"bus", true},
+	}
+	for _, tc := range cases {
+		err := validateProviderFieldName(tc.name)
+		if tc.wantErr && err == nil {
+			t.Errorf("validateProviderFieldName(%q) = nil, want error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("validateProviderFieldName(%q) = %v, want nil", tc.name, err)
+		}
+	}
+}
+
+func TestMakeDot_RejectsInvalidFieldNames(t *testing.T) {
+	for _, name := range []string{"", "db", "1x"} {
+		_, err := makeDot([]Provider{&testProvider{Name: name, Val: "x"}})
+		if err == nil {
+			t.Errorf("makeDot with FieldName %q: want error, got nil", name)
+		}
+	}
+}
+
+func TestInstance_RejectsInvalidProviderFieldName(t *testing.T) {
+	cfg, err := New().Options(
+		WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})),
+		WithProvider(&testProvider{Name: "db", Val: "x"}),
+	)
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	_, err = cfg.Instance()
+	if err == nil {
+		t.Fatal("Instance with lowercase field name: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exported") && !strings.Contains(err.Error(), "db") {
+		t.Errorf("error = %v, want mention of exported/db", err)
+	}
+}
 
 func TestMakeDotHappyPath(t *testing.T) {
 	// Reuse testProvider from providers_test.go (same package).

--- a/examples/dotprovider/README.md
+++ b/examples/dotprovider/README.md
@@ -15,9 +15,10 @@ Then open http://localhost:9006/.
 ## Writing a dot provider
 
 Implement `xtemplate.Provider` (`FieldName() string`, `Prototype() any`,
-`Value(http.ResponseWriter, *http.Request) (any, error)`), then register the
-instance via `xtemplate.WithProvider(p)` passed to `app.Main`. `FieldName` is
-the dot field name (`Shop` here); `Prototype` is a typed zero for reflection;
-`Value` returns the value assigned to `{{.Shop}}` for each request. `Init` is
-optional (save the instance context there if request-time code needs it). See
-`main.go`.
+`Value(http.ResponseWriter, *http.Request) (any, error)`), then register a
+factory via `xtemplate.WithProvider(func() xtemplate.Provider { return p })`
+passed to `app.Main`. Each Instance / Reload invokes the factory for a fresh
+provider value. `FieldName` is the dot field name (`Shop` here); `Prototype` is
+a typed zero for reflection; `Value` returns the value assigned to `{{.Shop}}`
+for each request. `Init` is optional (save the instance context there if
+request-time code needs it). See `main.go`.

--- a/examples/dotprovider/main.go
+++ b/examples/dotprovider/main.go
@@ -3,7 +3,7 @@
 // over products and look one up by id.
 //
 // To write a dot provider: implement xtemplate.Provider (FieldName,
-// Prototype, Value), then register the instance with xtemplate.WithProvider
+// Prototype, Value), then register a factory with xtemplate.WithProvider
 // passed to app.Main. FieldName is the dot field name; Prototype is a typed
 // zero value for reflection; Value returns the value assigned to that field
 // for each request. Init is optional (Initializer).
@@ -53,5 +53,7 @@ func (shopProvider) Value(http.ResponseWriter, *http.Request) (any, error) {
 }
 
 func main() {
-	app.Main(xtemplate.WithProvider(shopProvider{}))
+	app.Main(xtemplate.WithProvider(func() xtemplate.Provider {
+		return shopProvider{}
+	}))
 }

--- a/handlers.go
+++ b/handlers.go
@@ -4,6 +4,7 @@ package xtemplate
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -43,6 +44,16 @@ func bufferingTemplateHandler(server *Instance, tmpl *template.Template) http.Ha
 		err = tmpl.Execute(buf, *dot)
 
 		if err = server.bufferDot.cleanup(dot, err); err != nil {
+			if errors.Is(err, errResponseServed) {
+				// ServeContent already wrote the full response; do not append buffer.
+				return
+			}
+			var es ErrorStatus
+			if errors.As(err, &es) {
+				// Finalize already applied the intended status; do not overwrite with 500.
+				log.Warn("template returned error status", slog.Int("status", int(es)), slog.Any("error", err))
+				return
+			}
 			log.Warn("error executing template", slog.Any("error", err))
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
@@ -75,8 +86,15 @@ func flushingTemplateHandler(server *Instance, tmpl *template.Template) http.Han
 		err = tmpl.Execute(w, *dot)
 
 		if err = server.flusherDot.cleanup(dot, err); err != nil {
-			log.Info("error executing template", slog.Any("error", err))
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			// Stream may already have headers/body; do not call http.Error (would
+			// append a spurious 500 body). ErrorStatus cannot change SSE status
+			// after Content-Type is set; log only.
+			var es ErrorStatus
+			if errors.As(err, &es) {
+				log.Info("SSE template returned error status after stream start", slog.Int("status", int(es)), slog.Any("error", err))
+			} else {
+				log.Info("error executing template", slog.Any("error", err))
+			}
 			return
 		}
 	}

--- a/instance.go
+++ b/instance.go
@@ -225,6 +225,9 @@ func (config *Config) buildInstance() (_ *Instance, err error) {
 		seen := map[string]bool{}
 		for _, d := range dot {
 			name := d.FieldName()
+			if err := validateProviderFieldName(name); err != nil {
+				return nil, fmt.Errorf("dot provider %T: %w", d, err)
+			}
 			if seen[name] {
 				return nil, fmt.Errorf("dot field name '%s' is used more than once", name)
 			}

--- a/instance.go
+++ b/instance.go
@@ -187,6 +187,12 @@ func (config *Config) buildInstance() (_ *Instance, err error) {
 		if strings.HasSuffix(path_, build.config.TemplateExtension) {
 			err = build.addTemplateHandler(path_)
 		} else {
+			// Do not serve hidden basenames as static routes (e.g. .env,
+			// config/.htpasswd). Aligns with path templates, which parse hidden
+			// files into the namespace but register no file-based GET route.
+			if base := filepath.Base(path_); len(base) > 0 && base[0] == '.' {
+				return nil
+			}
 			err = build.addStaticFileHandler(path_)
 		}
 		return err

--- a/instance.go
+++ b/instance.go
@@ -137,10 +137,10 @@ func (config *Config) buildInstance() (_ *Instance, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp dir for pre-compressed files: %w", err)
 		}
-		go func() {
-			<-inst.config.Ctx.Done()
-			_ = os.RemoveAll(tempdir)
-		}()
+		// Remove after drain/Close to avoid race with in-flight static serves
+		inst.config.onClose = append(inst.config.onClose, func() error {
+			return os.RemoveAll(tempdir)
+		})
 		overlay := afero.NewBasePathFs(afero.NewOsFs(), tempdir)
 		inst.config.TemplateFS = afero.NewCopyOnWriteFs(inst.config.TemplateFS, overlay)
 	}

--- a/instance.go
+++ b/instance.go
@@ -221,7 +221,11 @@ func (config *Config) buildInstance() (_ *Instance, err error) {
 		if dot, err = resolveProviders(build.config.ProvidersRaw); err != nil {
 			return nil, err
 		}
-		dot = append(dot, build.config.Providers...)
+		goDot, err := materializeFactories(build.config.Providers)
+		if err != nil {
+			return nil, err
+		}
+		dot = append(dot, goDot...)
 		seen := map[string]bool{}
 		for _, d := range dot {
 			name := d.FieldName()

--- a/instance_test.go
+++ b/instance_test.go
@@ -198,6 +198,32 @@ func TestInstance_SkipsHiddenDirs(t *testing.T) {
 	}
 }
 
+// TestInstance_SkipsHiddenStaticBasenames ensures files like .env under a
+// normal directory are not registered as public static routes.
+func TestInstance_SkipsHiddenStaticBasenames(t *testing.T) {
+	inst := buildInstance(t, map[string]string{
+		"index.html":          "ok",
+		".env":                "SECRET=1",
+		"config/.htpasswd":    "user:hash",
+		"assets/app.css":      "body{}",
+		"shared/.head.html":   `{{define "head"}}H{{end}}`,
+		"use-head.html":       `{{template "head" .}}`,
+	})
+
+	for _, target := range []string{"/.env", "/config/.htpasswd"} {
+		if w := doRequest(inst, http.MethodGet, target); w.Code != http.StatusNotFound {
+			t.Errorf("hidden static %s status = %d, want %d", target, w.Code, http.StatusNotFound)
+		}
+	}
+	if w := doRequest(inst, http.MethodGet, "/assets/app.css"); w.Code != http.StatusOK {
+		t.Errorf("visible static status = %d, want %d", w.Code, http.StatusOK)
+	}
+	// Hidden template basenames still parse into the namespace for {{template}}.
+	if w := doRequest(inst, http.MethodGet, "/use-head"); w.Code != http.StatusOK || w.Body.String() != "H" {
+		t.Errorf("hidden template define: status=%d body=%q", w.Code, w.Body.String())
+	}
+}
+
 func TestServer_ReloadSwapsContent(t *testing.T) {
 	server := buildServer(t, map[string]string{"index.html": "V1"})
 	defer server.Stop()

--- a/onclose_test.go
+++ b/onclose_test.go
@@ -49,7 +49,9 @@ func TestWithOnClose_ReverseOrderAfterProviders(t *testing.T) {
 	}
 
 	inst := buildInstance(t, map[string]string{"index.html": "ok"},
-		WithProvider(&closeOrderProvider{name: "P", onClose: func() { add("provider") }}),
+		WithProvider(func() Provider {
+			return &closeOrderProvider{name: "P", onClose: func() { add("provider") }}
+		}),
 		WithOnClose(func() error { add("onClose1"); return nil }),
 		WithOnClose(func() error { add("onClose2"); return nil }),
 	)
@@ -312,13 +314,17 @@ func TestWithOnClose_InitFailureClosesOpenedProviders(t *testing.T) {
 
 	cfg, err := New().Options(
 		WithTemplateFS(newMemFS(t, map[string]string{"index.html": "ok"})),
-		WithProvider(&initCloseProvider{
-			name:    "OK",
-			onClose: func() { add("provider-ok") },
+		WithProvider(func() Provider {
+			return &initCloseProvider{
+				name:    "OK",
+				onClose: func() { add("provider-ok") },
+			}
 		}),
-		WithProvider(&initCloseProvider{
-			name:    "Fail",
-			initErr: errors.New("init-fail"),
+		WithProvider(func() Provider {
+			return &initCloseProvider{
+				name:    "Fail",
+				initErr: errors.New("init-fail"),
+			}
 		}),
 		WithOnClose(func() error { add("onClose"); return nil }),
 	)

--- a/precompress_test.go
+++ b/precompress_test.go
@@ -114,6 +114,43 @@ func TestPrecompress_DoesNotServeUnconfiguredVariant(t *testing.T) {
 	}
 }
 
+// TestPrecompress_ReloadKeepsServing ensures precompressed files remain
+// servable after Reload (tempdir cleanup is on Close after drain, not cancel).
+func TestPrecompress_ReloadKeepsServing(t *testing.T) {
+	const css = "body { color: blue; }\n"
+	srv := buildServer(t, map[string]string{"style.css": css}, func(c *Config) error {
+		c.Precompress = []string{"gzip"}
+		return nil
+	})
+	defer srv.Stop()
+
+	if err := srv.Reload(WithTemplateFS(newMemFS(t, map[string]string{"style.css": css}))); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/style.css", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	srv.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if ce := w.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("Content-Encoding = %q, want gzip", ce)
+	}
+	gr, err := gzip.NewReader(w.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	got, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != css {
+		t.Errorf("body = %q, want %q", got, css)
+	}
+}
+
 func TestPrecompress_SkipsExistingCompressedFile(t *testing.T) {
 	const css = "body { color: red; }\n"
 

--- a/providers.go
+++ b/providers.go
@@ -5,16 +5,21 @@ import (
 	"fmt"
 )
 
+// ProviderFactory constructs a fresh [Provider] value. Sticky [Config.Providers]
+// hold factories so each Instance / Reload build materializes new providers
+// (matching JSON [resolveProviders] + registry constructors).
+type ProviderFactory func() Provider
+
 // registry maps type-string → constructor.
 // Written only in init(), read-only afterward.
 // ponytail: init()-only writes; race-free by Go's init happens-before guarantee.
 // Add a sync.RWMutex if runtime registration becomes supported.
-var registry = map[string]func() Provider{}
+var registry = map[string]ProviderFactory{}
 
 // RegisterProvider makes a provider type available to resolveProviders. Call from init().
 // Panics on duplicate registration (names the type in the message; the registering
 // package is identified by the runtime's stack trace).
-func RegisterProvider(name string, ctor func() Provider) {
+func RegisterProvider(name string, ctor ProviderFactory) {
 	if _, exists := registry[name]; exists {
 		panic(fmt.Sprintf("xtemplate: provider type %q already registered", name))
 	}
@@ -47,6 +52,26 @@ func resolveProviders(raw []json.RawMessage) ([]Provider, error) {
 		p := ctor()
 		if err := json.Unmarshal(msg, p); err != nil {
 			return nil, fmt.Errorf("xtemplate: failed to decode provider %q config: %w", probe.Type, err)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// materializeFactories invokes each sticky Go [ProviderFactory] for one Instance
+// build. Rejects a nil factory or a factory that returns nil.
+func materializeFactories(fs []ProviderFactory) ([]Provider, error) {
+	if len(fs) == 0 {
+		return nil, nil
+	}
+	out := make([]Provider, 0, len(fs))
+	for i, f := range fs {
+		if f == nil {
+			return nil, fmt.Errorf("xtemplate: nil provider factory at index %d", i)
+		}
+		p := f()
+		if p == nil {
+			return nil, fmt.Errorf("xtemplate: provider factory at index %d returned nil", i)
 		}
 		out = append(out, p)
 	}

--- a/providers/dotbus/bus.go
+++ b/providers/dotbus/bus.go
@@ -107,6 +107,19 @@ func (b *Bus) removeLocked(ch <-chan string) {
 	}
 }
 
+// Kick closes every subscriber channel and clears topic maps, but leaves the
+// bus open for further Publish/Subscribe. Used on instance context cancel so
+// in-flight SSE ranges end while grace-period handlers can still publish.
+// No-op after Shutdown. Safe to call more than once.
+func (b *Bus) Kick() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.closeSubscribersLocked()
+}
+
 // Shutdown closes every subscriber channel and rejects further Publish/Subscribe.
 // Safe to call more than once.
 func (b *Bus) Shutdown() {
@@ -116,6 +129,10 @@ func (b *Bus) Shutdown() {
 		return
 	}
 	b.closed = true
+	b.closeSubscribersLocked()
+}
+
+func (b *Bus) closeSubscribersLocked() {
 	for c := range b.reverse {
 		close(c)
 	}

--- a/providers/dotbus/bus_test.go
+++ b/providers/dotbus/bus_test.go
@@ -182,6 +182,40 @@ func TestShutdown(t *testing.T) {
 	b.Shutdown() // idempotent
 }
 
+func TestKick(t *testing.T) {
+	b := New(2)
+	ch, err := b.Subscribe("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Kick()
+	if _, ok := <-ch; ok {
+		t.Fatal("expected closed channel after Kick")
+	}
+	// Bus still accepts Publish/Subscribe after Kick.
+	if err := b.Publish("t", "x"); err != nil {
+		t.Fatalf("Publish after Kick: %v", err)
+	}
+	ch2, err := b.Subscribe("t")
+	if err != nil {
+		t.Fatalf("Subscribe after Kick: %v", err)
+	}
+	if err := b.Publish("t", "y"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-ch2:
+		if got != "y" {
+			t.Fatalf("got %q, want y", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout after Kick")
+	}
+	b.Kick() // idempotent while open
+	b.Shutdown()
+	b.Kick() // no-op after Shutdown
+}
+
 func TestEmptyTopic(t *testing.T) {
 	b := New(1)
 	defer b.Shutdown()

--- a/providers/dotbus/dotbus.go
+++ b/providers/dotbus/dotbus.go
@@ -20,11 +20,11 @@ func init() {
 
 // WithBus creates an [xtemplate.Option] that adds a bus dot provider.
 // buffer is the per-subscriber channel capacity; 0 means [DefaultBuffer].
+// Each Instance / Reload build gets a fresh [DotBusConfig] and bus.
 func WithBus(name string, buffer int) xtemplate.Option {
-	return func(c *xtemplate.Config) error {
-		c.Providers = append(c.Providers, &DotBusConfig{Name: name, Buffer: buffer})
-		return nil
-	}
+	return xtemplate.WithProvider(func() xtemplate.Provider {
+		return &DotBusConfig{Name: name, Buffer: buffer}
+	})
 }
 
 // DotBusConfig configures an xtemplate dot field for in-process topic fan-out.

--- a/providers/dotbus/dotbus.go
+++ b/providers/dotbus/dotbus.go
@@ -48,8 +48,8 @@ func (d *DotBusConfig) FieldName() string { return d.Name }
 // Prototype returns the per-request field type.
 func (d *DotBusConfig) Prototype() any { return &DotBus{} }
 
-// Init validates config and creates the bus. Call [Close] (or cancel the
-// instance context) to shut the bus down on reload/stop.
+// Init validates config and creates the bus. Instance context cancel [Kick]s
+// subscribers (so SSE ranges end); [Close] fully shuts the bus down after drain.
 func (d *DotBusConfig) Init(ctx context.Context) error {
 	if d.Name == "" {
 		return fmt.Errorf("bus: name is required")
@@ -61,7 +61,7 @@ func (d *DotBusConfig) Init(ctx context.Context) error {
 	if done := ctx.Done(); done != nil {
 		go func() {
 			<-done
-			d.bus.Shutdown()
+			d.bus.Kick()
 		}()
 	}
 	return nil

--- a/providers/dotbus/dotbus_test.go
+++ b/providers/dotbus/dotbus_test.go
@@ -149,7 +149,7 @@ func TestDotBusConfig_Init(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	}
-	cancel() // shuts down bus via Init's ctx watcher
+	cancel() // Kick via Init's ctx watcher closes subscriber channels
 	select {
 	case _, ok := <-ch:
 		if ok {
@@ -158,7 +158,17 @@ func TestDotBusConfig_Init(t *testing.T) {
 			}
 		}
 	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for close after Shutdown")
+		t.Fatal("timeout waiting for channel close after Kick")
+	}
+	// Kick leaves the bus open for Publish.
+	if err := dot.Publish("t", "after-kick"); err != nil {
+		t.Fatalf("Publish after Kick: %v", err)
+	}
+	if err := cfg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := dot.Publish("t", "x"); err == nil {
+		t.Fatal("Publish after Close should fail")
 	}
 }
 

--- a/providers/dotbus/dotbus_test.go
+++ b/providers/dotbus/dotbus_test.go
@@ -195,6 +195,47 @@ func TestDotBus_WithBusOption(t *testing.T) {
 	}
 }
 
+// TestDotBus_ReloadIsolatesInstances ensures sticky WithBus factories produce
+// a new bus per Reload, so retiring the previous instance does not Close the
+// live bus (the sticky-provider Init/Close bug).
+func TestDotBus_ReloadIsolatesInstances(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	if err := afero.WriteFile(fs, "pub.html", []byte(`{{.Bus.Publish "t" "hi"}}ok`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := xtemplate.New().Options(
+		xtemplate.WithTemplateFS(fs),
+		dotbus.WithBus("Bus", 8),
+	)
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	srv, err := cfg.Server()
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	publishOK := func(label string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/pub", nil))
+		if w.Code != http.StatusOK || w.Body.String() != "ok" {
+			t.Fatalf("%s: status=%d body=%q (bus may have been closed by prior instance)", label, w.Code, w.Body.String())
+		}
+	}
+
+	publishOK("initial")
+	if err := srv.Reload(); err != nil {
+		t.Fatalf("Reload 1: %v", err)
+	}
+	publishOK("after reload 1")
+	if err := srv.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	publishOK("after reload 2")
+}
+
 func TestDotBus_RequestCancelUnsubscribes(t *testing.T) {
 	cfg := &dotbus.DotBusConfig{Name: "Bus", Buffer: 4}
 	if err := cfg.Init(context.Background()); err != nil {

--- a/providers/dotflags/flags.go
+++ b/providers/dotflags/flags.go
@@ -21,14 +21,16 @@ func (d DotFlags) Value(key string) string {
 }
 
 // WithFlags creates an [xtemplate.Option] that adds a flags dot provider to
-// the config.
+// the config. The map is shared across builds (read-only config); each build
+// gets a fresh [DotFlagsConfig].
 func WithFlags(name string, flags map[string]string) xtemplate.Option {
 	return func(c *xtemplate.Config) error {
 		if flags == nil {
 			return fmt.Errorf("cannot create DotFlagsProvider with null map with name %s", name)
 		}
-		c.Providers = append(c.Providers, &DotFlagsConfig{name, flags})
-		return nil
+		return xtemplate.WithProvider(func() xtemplate.Provider {
+			return &DotFlagsConfig{name, flags}
+		})(c)
 	}
 }
 

--- a/providers/dotfs/fs.go
+++ b/providers/dotfs/fs.go
@@ -98,8 +98,9 @@ func withFs(name string, afs afero.Fs, writable bool) xtemplate.Option {
 		if afs == nil {
 			return fmt.Errorf("cannot create DotFSProvider with null FS with name %s", name)
 		}
-		c.Providers = append(c.Providers, &DotFsConfig{Name: name, FS: afs, Writable: writable})
-		return nil
+		return xtemplate.WithProvider(func() xtemplate.Provider {
+			return &DotFsConfig{Name: name, FS: afs, Writable: writable}
+		})(c)
 	}
 }
 

--- a/providers/dotnats/nats.go
+++ b/providers/dotnats/nats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/infogulch/xtemplate"
@@ -56,7 +57,9 @@ var (
 func (d *DotNatsConfig) FieldName() string { return d.Name }
 func (d *DotNatsConfig) Prototype() any    { return &DotNats{} }
 
-func (d *DotNatsConfig) Init(ctx context.Context) error {
+// Init opens owned connections/servers. Instance context cancel does not destroy
+// them; [Close] does after in-flight drain.
+func (d *DotNatsConfig) Init(_ context.Context) error {
 	var err error
 	if d.Conn != nil {
 		if d.js == nil {
@@ -79,35 +82,48 @@ func (d *DotNatsConfig) Init(ctx context.Context) error {
 		connOpt = *d.ConnOptions
 	}
 	if d.InProcessServerOptions != nil {
-		// start an internal server for this instance
+		// start an internal server for this instance; destroyed only in Close
+		// after drain so grace-period handlers keep a live server.
 		d.server, err = server.NewServer(d.InProcessServerOptions)
 		if err != nil {
 			return fmt.Errorf("failed to start in-process nats server: %w", err)
 		}
 		d.server.Start()
 
-		// shut down the server when the instance is cancelled
-		done := ctx.Done()
-		if done != nil {
-			go func() {
-				<-done
-				d.server.Shutdown()
-			}()
-		}
-
 		_ = nats.InProcessServer(d.server)(&connOpt)
 	}
 	d.Conn, err = connOpt.Connect()
 	if err != nil {
-		return fmt.Errorf("failed to connect to in-process server: %w", err)
+		d.cleanupPartial()
+		return fmt.Errorf("failed to connect to nats server: %w", err)
 	}
 	d.owned = true
 	d.js, err = jetstream.New(d.Conn, d.JetStreamOptions...)
-	return err
+	if err != nil {
+		d.cleanupPartial()
+		return err
+	}
+	return nil
+}
+
+// cleanupPartial releases resources opened during a failed Init before Closer
+// registration. Safe if nothing was opened yet.
+func (d *DotNatsConfig) cleanupPartial() {
+	if d.Conn != nil {
+		d.Conn.Close()
+		d.Conn = nil
+	}
+	d.owned = false
+	d.js = nil
+	if d.server != nil {
+		d.server.Shutdown()
+		d.server = nil
+	}
 }
 
 // Close drains/closes a connection opened by Init and shuts down any in-process
-// server. Injected connections are left alone.
+// server. Injected connections are left alone. Call after in-flight drain so
+// grace-period handlers still see a live connection/server.
 func (d *DotNatsConfig) Close() error {
 	var err error
 	if d.owned && d.Conn != nil {
@@ -134,9 +150,25 @@ type DotNats struct {
 	jetstream.JetStream
 }
 
+// Subscribe returns a channel of messages on subject. The channel is closed
+// when the request context is cancelled. Delivery uses a buffered callback so
+// teardown cannot race with send-on-closed-channel.
 func (d *DotNats) Subscribe(subject string) (<-chan *nats.Msg, error) {
-	ch := make(chan *nats.Msg)
-	sub, err := d.ChanSubscribe(subject, ch)
+	ch := make(chan *nats.Msg, 16)
+	var mu sync.Mutex
+	open := true
+	sub, err := d.Conn.Subscribe(subject, func(m *nats.Msg) {
+		mu.Lock()
+		defer mu.Unlock()
+		if !open {
+			return
+		}
+		select {
+		case ch <- m:
+		default:
+			// drop when consumer is slow (best-effort, like bus fan-out)
+		}
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +176,12 @@ func (d *DotNats) Subscribe(subject string) (<-chan *nats.Msg, error) {
 	go func() {
 		<-done
 		_ = sub.Unsubscribe()
-		close(ch)
+		mu.Lock()
+		if open {
+			open = false
+			close(ch)
+		}
+		mu.Unlock()
 	}()
 	return ch, nil
 }

--- a/providers/dotnats/nats.go
+++ b/providers/dotnats/nats.go
@@ -18,12 +18,12 @@ func init() {
 }
 
 // WithNats creates an [xtemplate.Option] that adds a nats dot provider to the
-// config.
+// config. Each Instance / Reload build gets a fresh [DotNatsConfig]; options
+// pointers are shared via the factory closure.
 func WithNats(name string, serverOpts *server.Options, connOpts *nats.Options, jsOpts []jetstream.JetStreamOpt) xtemplate.Option {
-	return func(c *xtemplate.Config) error {
-		c.Providers = append(c.Providers, &DotNatsConfig{Name: name, NatsConfig: &NatsConfig{serverOpts, connOpts, jsOpts}})
-		return nil
-	}
+	return xtemplate.WithProvider(func() xtemplate.Provider {
+		return &DotNatsConfig{Name: name, NatsConfig: &NatsConfig{serverOpts, connOpts, jsOpts}}
+	})
 }
 
 // NatsConfig holds the configuration needed to connect to a NATS server.

--- a/providers/dotnats/nats_test.go
+++ b/providers/dotnats/nats_test.go
@@ -77,7 +77,9 @@ func TestDotNats_Request(t *testing.T) {
 		map[string]string{
 			"req.html": `{{$m := .Nats.Request "echo" "ping"}}{{printf "%s" $m.Data}}`,
 		},
-		xtemplate.WithProvider(&dotnats.DotNatsConfig{Name: "Nats", Conn: nc}),
+		xtemplate.WithProvider(func() xtemplate.Provider {
+			return &dotnats.DotNatsConfig{Name: "Nats", Conn: nc}
+		}),
 	)
 
 	w := doRequest(inst, http.MethodGet, "/req")
@@ -104,7 +106,9 @@ func TestDotNats_Publish(t *testing.T) {
 		map[string]string{
 			"pub.html": `{{$_ := .Nats.Publish "events" "hello"}}ok`,
 		},
-		xtemplate.WithProvider(&dotnats.DotNatsConfig{Name: "Nats", Conn: nc}),
+		xtemplate.WithProvider(func() xtemplate.Provider {
+			return &dotnats.DotNatsConfig{Name: "Nats", Conn: nc}
+		}),
 	)
 
 	w := doRequest(inst, http.MethodGet, "/pub")
@@ -120,4 +124,45 @@ func TestDotNats_Publish(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for published message")
 	}
+}
+
+// TestDotNats_ReloadIsolatesInstances ensures sticky WithNats factories produce
+// a fresh owned Conn/server per Reload, so retiring the previous instance does
+// not Close resources still used by the live instance.
+func TestDotNats_ReloadIsolatesInstances(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	if err := afero.WriteFile(fs, "pub.html", []byte(`{{$_ := .Nats.Publish "events" "hi"}}ok`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := xtemplate.New().Options(
+		xtemplate.WithTemplateFS(fs),
+		dotnats.WithNats("Nats", &server.Options{DontListen: true}, nil, nil),
+	)
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	srv, err := cfg.Server()
+	if err != nil {
+		t.Fatalf("Server: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	publishOK := func(label string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/pub", nil))
+		if w.Code != http.StatusOK || w.Body.String() != "ok" {
+			t.Fatalf("%s: status=%d body=%q (nats may have been closed by prior instance)", label, w.Code, w.Body.String())
+		}
+	}
+
+	publishOK("initial")
+	if err := srv.Reload(); err != nil {
+		t.Fatalf("Reload 1: %v", err)
+	}
+	publishOK("after reload 1")
+	if err := srv.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	publishOK("after reload 2")
 }

--- a/providers/dotsmtp/smtp.go
+++ b/providers/dotsmtp/smtp.go
@@ -25,11 +25,16 @@ func init() {
 // WithSMTP creates an [xtemplate.Option] that adds an smtp dot provider to the
 // config. It is a thin convenience over [xtemplate.WithProvider] for Go-API
 // users; Caddyfile/JSON users configure the provider via its struct fields.
-func WithSMTP(cfg *DotSMTPConfig) xtemplate.Option {
-	return func(c *xtemplate.Config) error {
-		c.Providers = append(c.Providers, cfg)
-		return nil
-	}
+//
+// cfg is copied by value when WithSMTP is called (frozen at option construction).
+// Each Instance / Reload build gets another field-copy with the runtime client
+// cleared so Init does not re-initialize sticky state.
+func WithSMTP(cfg DotSMTPConfig) xtemplate.Option {
+	return xtemplate.WithProvider(func() xtemplate.Provider {
+		cp := cfg
+		cp.client = nil
+		return &cp
+	})
 }
 
 // DotSMTPConfig configures an xtemplate dot field that provides SMTP mail

--- a/providers/dotsmtp/smtp_test.go
+++ b/providers/dotsmtp/smtp_test.go
@@ -263,23 +263,18 @@ func TestRecipientShapes(t *testing.T) {
 func TestDotSMTP_Send_Integration(t *testing.T) {
 	srv := newMockSMTP(t)
 
-	cfg := &DotSMTPConfig{
-		Name: "Email",
-		Host: "127.0.0.1",
-		Port: srv.PortNumber(),
-		From: "noreply@example.com",
-		TLS:  "none",
-		Helo: "localhost",
-	}
-	if err := cfg.Init(context.Background()); err != nil {
-		t.Fatalf("Init: %v", err)
-	}
-
 	inst := buildInstance(t,
 		map[string]string{
 			"send.html": `{{ $id := .Email.Send "test@example.com" "Hello" "<p>World</p>" }}{{ $id }}`,
 		},
-		xtemplate.WithProvider(cfg),
+		WithSMTP(DotSMTPConfig{
+			Name: "Email",
+			Host: "127.0.0.1",
+			Port: srv.PortNumber(),
+			From: "noreply@example.com",
+			TLS:  "none",
+			Helo: "localhost",
+		}),
 	)
 
 	w := doRequest(inst, http.MethodGet, "/send")

--- a/providers/dotsql/sql.go
+++ b/providers/dotsql/sql.go
@@ -18,13 +18,17 @@ func init() {
 	xtemplate.RegisterProvider("sql", func() xtemplate.Provider { return &DotSqlConfig{} })
 }
 
+// WithSql adds a SQL provider that uses the injected *sql.DB (not closed by
+// the provider). Each Instance / Reload build gets a fresh [DotSqlConfig];
+// the DB handle is shared intentionally.
 func WithSql(name string, db *sql.DB, opt *sql.TxOptions) xtemplate.Option {
 	return func(c *xtemplate.Config) error {
 		if db == nil {
 			return fmt.Errorf("cannot create database provider with nil sql.DB. name: %s", name)
 		}
-		c.Providers = append(c.Providers, &DotSqlConfig{Name: name, DB: db, TxOptions: opt})
-		return nil
+		return xtemplate.WithProvider(func() xtemplate.Provider {
+			return &DotSqlConfig{Name: name, DB: db, TxOptions: opt}
+		})(c)
 	}
 }
 

--- a/providers_test.go
+++ b/providers_test.go
@@ -73,3 +73,26 @@ func TestRegisterProvider_duplicatePanics(t *testing.T) {
 	}()
 	RegisterProvider("_test", func() Provider { return &testProvider{} })
 }
+
+func TestMaterializeFactories(t *testing.T) {
+	got, err := materializeFactories([]ProviderFactory{
+		func() Provider { return &testProvider{Name: "A", Val: "1"} },
+		func() Provider { return &testProvider{Name: "B", Val: "2"} },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].FieldName() != "A" || got[1].FieldName() != "B" {
+		t.Fatalf("unexpected providers: %+v", got)
+	}
+
+	if _, err := materializeFactories([]ProviderFactory{nil}); err == nil {
+		t.Fatal("expected error for nil factory")
+	}
+	if _, err := materializeFactories([]ProviderFactory{func() Provider { return nil }}); err == nil {
+		t.Fatal("expected error for factory returning nil")
+	}
+	if got, err := materializeFactories(nil); err != nil || got != nil {
+		t.Fatalf("empty: got %v err %v", got, err)
+	}
+}


### PR DESCRIPTION
- **Precompress:** Remove overlay tempdir on Close after drain, not on instance cancel
- **Responses:** Preserve `ErrorStatus` instead of overwriting with 500; skip template buffer after `ServeContent`; accept `[]byte` / reject bad types; no `http.Error` after SSE has started.
- **Static / config:** Do not serve hidden basenames (e.g. `.env`) as static routes; validate provider field names before `reflect.StructOf`.
- **Dot Struct:** Validate user-chosen dot field names and emit readable error messages instead of panicing
- **Bus/NATS:** Utilize grace period to close out flush handlers waiting on Bus/NATS events
- **Provider Factories:** Refactored to avoid provider initialization/finalization from trampling the same provider instance

## Test plan

- [x] `mise test`
- [x] CI on this PR